### PR TITLE
[FEATURE] Remove local APE 1.1.7 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ It is set up with different use cases from the [APE Use Cases Repository](https:
 
 ### Using Docker
 
-Currently, the APE Web back-end uses a version of APE which is not available on the Maven repository.
-To be able to build the back-end container, please download and build [APE 1.1.7](https://github.com/sanctuuary/APE/releases/tag/v1.1.7) first,
-and place it in the back-end directory.
-
-APE Web can be easily deployed using Docker Compose, simply by running:
+Please follow the configuration instructions in the [front-end](https://github.com/sanctuuary/APE-Web/blob/master/front-end/README.md)
+and [back-end](https://github.com/sanctuuary/APE-Web/blob/master/back-end/README.md) README files first.
+After configuring, APE Web can be easily deployed using Docker Compose, simply by running:
 ```shell
 docker-compose up -d
 ```

--- a/back-end/Dockerfile
+++ b/back-end/Dockerfile
@@ -3,9 +3,6 @@
 FROM maven:3.6.3-adoptopenjdk-11
 WORKDIR /app
 COPY pom.xml /app
-COPY APE-*.jar /app/
-# Install APE 1.1.7 locally, as it's currently not available in the online maven repository
-RUN mvn install:install-file -Dfile="APE-1.1.7.jar"
 RUN mvn compile
 COPY . /app
 RUN mvn package -DskipTests=true -P docker

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -13,15 +13,7 @@ For instruction for Docker, please see the README file in the project root.
 
 ### Build APE Web back-end from source
 
-Currently, the APE Web back-end uses a version of APE which is not available on the Maven repository.
-To build the APE Web back-end from source, please download and build [APE 1.1.7](https://github.com/sanctuuary/APE/releases/tag/v1.1.7) first,
-and place it in this directory.
-Then, run the following command in this directory:
-````shell
-$ mvn install:install-file -Dfile=APE-1.1.7.jar
-````
-This adds APE 1.1.7 to your local Maven repository.
-You can now build the back-end using
+In this directory, simply run:
 ````shell
 $ mvn package -DskipTests=true
 ````


### PR DESCRIPTION
Previously, APE 1.1.7 was not available in the online Maven repository. Recently, APE 1.1.7 has been made available in the repository.
- Remove the local APE 1.1.7 installation steps in the back-end's Dockerfile.
- Remove the local APE 1.1.7 install instructions from the README files.