### PR TITLE
Fix uploading new domains creating corrupted domains

### DIFF
--- a/front-end/src/pages/api/domain/upload.tsx
+++ b/front-end/src/pages/api/domain/upload.tsx
@@ -23,7 +23,13 @@ export default async function handler(req, res) {
   const { values, fileContents } = req.body;
   const formdata = new FormData();
   Object.keys(values).forEach((key) => {
-    // Topics and dataDimensionsTaxonomyRoots should be handled separately, skip them here.
+    /*
+     * Topics and dataDimensionsTaxonomyRoots should be handled separately, skip them here.
+     *
+     * They should be handled separately, because in the case of arrays,
+     * each element in the array should be its own FormData entry.
+     * Otherwise, all elements in the array are received as one element on the back-end.
+     */
     if (key !== 'topics' && key !== 'dataDimensionsTaxonomyRoots') {
       formdata.append(key, values[key]);
     }

--- a/front-end/src/pages/api/domain/upload.tsx
+++ b/front-end/src/pages/api/domain/upload.tsx
@@ -23,13 +23,14 @@ export default async function handler(req, res) {
   const { values, fileContents } = req.body;
   const formdata = new FormData();
   Object.keys(values).forEach((key) => {
-    // Topics should be handled separately, skip them here.
-    if (key !== 'topics') {
+    // Topics and dataDimensionsTaxonomyRoots should be handled separately, skip them here.
+    if (key !== 'topics' && key !== 'dataDimensionsTaxonomyRoots') {
       formdata.append(key, values[key]);
     }
   });
   // Add topics
   Object.values(values.topics).forEach((topic: string) => formdata.append('topics', topic));
+  Object.values(values.dataDimensionsTaxonomyRoots).forEach((root: string) => formdata.append('dataDimensionsTaxonomyRoots', root));
 
   fileContents.forEach((fc: FileContent) => {
     formdata.append(


### PR DESCRIPTION
The dataDimensionsTaxonomyRoots were not formatted correctly in the front-end proxy. This caused all taxonomy roots to be send as one. This fixes the formatting so they are received correctly on the back-end.