### PR TITLE
[FEATURE] Configurable run parameter limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Endpoint to PUT new global run parameters limits.
 - Front-end gets run parameters limits from back-end.
 - Admin page allows configuring the global run parameters limits.
+- Back-end checks if a workflow run does not exceed the configured run parameters limits.
 
 ### Changed
 - Removed required steps to install APE 1.1.7 to local Maven repository, replaced with instructions to optionally use a different version of APE when compiling the back-end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A link to the official running instance of APE Web in the README.
 - CHANGELOG.md file.
 - Terms and conditions page.
+- Endpoint to GET global run parameters limits.
+- Endpoint to PUT new global run parameters limits.
+- Front-end gets run parameters limits from back-end.
+- Admin page allows configuring the global run parameters limits.
 
 ### Changed
-- Remove required steps to install APE 1.1.7 to local Maven repository, replace with instructions to optionally use a different version of APE when compiling the back-end.
+- Removed required steps to install APE 1.1.7 to local Maven repository, replaced with instructions to optionally use a different version of APE when compiling the back-end.
 - Update the footer links to point to the APE Web GitHub repository.
+- Reduced the size of the headers on the admin page.
 
 ### Removed
 - Vacancies link in footer.
@@ -22,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain upload creating corrupted domains.
 - "Sign out" button in header.
 - "Go to login" on admin page's unauthorized result.
+- Max run duration being the max length/steps when downloading configuration files.
+- Unknown "text" HTML element error on explore page.
 
 ## 1.0.0 - 2021-05-03
 

--- a/back-end/src/main/kotlin/com/apexdevs/backend/ape/ApeRequestFactory.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/ape/ApeRequestFactory.kt
@@ -4,6 +4,7 @@
  */
 package com.apexdevs.backend.ape
 
+import com.apexdevs.backend.persistence.RunParametersOperation
 import com.apexdevs.backend.persistence.database.entity.Domain
 import com.apexdevs.backend.persistence.filesystem.FileService
 import com.apexdevs.backend.persistence.filesystem.FileTypes
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Component
  * @param fileService interface for filesystem operations
  */
 @Component
-class ApeRequestFactory(val fileService: FileService) {
+class ApeRequestFactory(val fileService: FileService, val runParametersOperation: RunParametersOperation) {
 
     private val activeApeRequests = mutableMapOf<String, ApeRequest>()
 
@@ -31,7 +32,7 @@ class ApeRequestFactory(val fileService: FileService) {
             if (!activeApeRequests.containsKey(userID)) {
                 val ape = createNewApeInstance(domain)
 
-                val apeRequest = ApeRequest(it, fileService.rootLocation, ape)
+                val apeRequest = ApeRequest(it, fileService.rootLocation, ape, runParametersOperation)
 
                 activeApeRequests[userID] = apeRequest
                 return apeRequest

--- a/back-end/src/main/kotlin/com/apexdevs/backend/ape/entity/workflow/RunConfig.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/ape/entity/workflow/RunConfig.kt
@@ -25,9 +25,9 @@ import org.json.JSONObject
  *  @param maxDuration The maximum amount of time ape is allowed to run its computation, in seconds
  */
 data class RunConfig(
-    private val solutionMinLength: Int,
-    private val solutionMaxLength: Int,
-    private val maxSolutionsToReturn: Int,
+    val solutionMinLength: Int,
+    val solutionMaxLength: Int,
+    val maxSolutionsToReturn: Int,
     private val inputs: List<Data> = emptyList(),
     private val outputs: List<Data> = emptyList(),
     private val noExecutionScripts: Int = 0,
@@ -38,7 +38,7 @@ data class RunConfig(
     private val useWorkflowInput: String = "all",
     private val useGeneratedData: String = "all",
     private val constraints: List<Constraint>? = null,
-    private val maxDuration: Int = 10
+    val maxDuration: Int = 10
 ) {
     fun toJSONObject(): JSONObject {
         val json = JSONObject()

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
@@ -1,0 +1,70 @@
+package com.apexdevs.backend.persistence
+
+import com.apexdevs.backend.persistence.database.entity.RunParameters
+import com.apexdevs.backend.persistence.database.repository.RunParametersRepository
+import com.apexdevs.backend.persistence.exception.RunParametersNotFoundException
+import com.apexdevs.backend.web.controller.entity.runparameters.RunParametersDetails
+import org.bson.types.ObjectId
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Component
+
+/**
+ * Performs run parameters operations on the database
+ * @param runParametersRepository (autowired)
+ */
+@Component
+class RunParametersOperation(val runParametersRepository: RunParametersRepository) {
+    /**
+     * Create new run parameters
+     * @param runParameters run parameters to add to the database
+     * @throws DuplicateKeyException if the key already exists
+     * @return The created run parameters
+     */
+    @Throws(DuplicateKeyException::class)
+    fun createRunParameters(runParameters: RunParameters): RunParameters {
+        try {
+            return runParametersRepository.insert(runParameters)
+        } catch (exception: DuplicateKeyException) {
+            throw DuplicateKeyException("These run parameters already exist")
+        }
+    }
+
+    /**
+     * Retrieves the run parameters by id and throws an exception if not found.
+     * @param id the id of the run parameters
+     * @throws RunParametersNotFoundException if the run parameters are not found
+     * @return RunParameters that match the id
+     */
+    @Throws(RunParametersNotFoundException::class)
+    fun getRunParameters(id: ObjectId): RunParameters {
+        val result = runParametersRepository.findById(id)
+
+        if (result.isEmpty)
+            throw RunParametersNotFoundException(this, id, "Requested run parameters were not found")
+
+        return result.get()
+    }
+
+    /**
+     * Update the given run parameters
+     * @param runParameters The new run parameters to save in the database
+     * @return The saved run parameters
+     */
+    fun updateRunParameters(runParameters: RunParameters): RunParameters {
+        return runParametersRepository.save(runParameters)
+    }
+
+    /**
+     * Returns run parameters information
+     * @param runParameters to retrieve information from
+     */
+    fun getRunParametersDetails(runParameters: RunParameters): RunParametersDetails {
+        return RunParametersDetails(
+            runParameters.id.toHexString(),
+            runParameters.minSteps.toString(),
+            runParameters.maxSteps.toString(),
+            runParameters.maxDuration.toString(),
+            runParameters.numberOfSolutions.toString()
+        )
+    }
+}

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
@@ -2,6 +2,7 @@ package com.apexdevs.backend.persistence
 
 import com.apexdevs.backend.persistence.database.entity.RunParameters
 import com.apexdevs.backend.persistence.database.repository.RunParametersRepository
+import com.apexdevs.backend.persistence.exception.GlobalRunParametersNotFoundException
 import com.apexdevs.backend.persistence.exception.RunParametersNotFoundException
 import com.apexdevs.backend.web.controller.entity.runparameters.RunParametersDetails
 import org.bson.types.ObjectId
@@ -66,5 +67,18 @@ class RunParametersOperation(val runParametersRepository: RunParametersRepositor
             runParameters.maxDuration.toString(),
             runParameters.numberOfSolutions.toString()
         )
+    }
+
+    /**
+     * Get the global run parameters settings
+     * @throws GlobalRunParametersNotFoundException when the global run parameters settings could not be found
+     * @return The global run parameters settings
+     */
+    fun getGlobalRunParameters(): RunParameters {
+        val list = runParametersRepository.findAll()
+        if (list.isEmpty()) {
+            throw GlobalRunParametersNotFoundException(this, "Global run parameters could not be found")
+        }
+        return list.first()
     }
 }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
@@ -2,7 +2,6 @@ package com.apexdevs.backend.persistence
 
 import com.apexdevs.backend.persistence.database.entity.RunParameters
 import com.apexdevs.backend.persistence.database.repository.RunParametersRepository
-import com.apexdevs.backend.persistence.exception.GlobalRunParametersNotFoundException
 import com.apexdevs.backend.persistence.exception.RunParametersNotFoundException
 import com.apexdevs.backend.web.controller.entity.runparameters.RunParametersDetails
 import org.bson.types.ObjectId
@@ -63,10 +62,10 @@ class RunParametersOperation(val runParametersRepository: RunParametersRepositor
     fun getRunParametersDetails(runParameters: RunParameters): RunParametersDetails {
         return RunParametersDetails(
             runParameters.id.toHexString(),
-            runParameters.minSteps.toString(),
-            runParameters.maxSteps.toString(),
+            runParameters.minLength.toString(),
+            runParameters.maxLength.toString(),
             runParameters.maxDuration.toString(),
-            runParameters.numberOfSolutions.toString()
+            runParameters.solutions.toString()
         )
     }
 

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/RunParametersOperation.kt
@@ -8,6 +8,7 @@ import com.apexdevs.backend.web.controller.entity.runparameters.RunParametersDet
 import org.bson.types.ObjectId
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Component
+import java.util.logging.Logger
 
 /**
  * Performs run parameters operations on the database
@@ -70,15 +71,21 @@ class RunParametersOperation(val runParametersRepository: RunParametersRepositor
     }
 
     /**
-     * Get the global run parameters settings
-     * @throws GlobalRunParametersNotFoundException when the global run parameters settings could not be found
+     * Get the global run parameters settings.
+     * If they didn't exist before, they will be created with the default values.
      * @return The global run parameters settings
      */
     fun getGlobalRunParameters(): RunParameters {
         val list = runParametersRepository.findAll()
         if (list.isEmpty()) {
-            throw GlobalRunParametersNotFoundException(this, "Global run parameters could not be found")
+            // Global run parameters settings didn't exist before, create it with default settings
+            log.info("No global run parameters settings found: creating them using default values.")
+            return createRunParameters(RunParameters())
         }
         return list.first()
+    }
+
+    companion object {
+        val log: Logger = Logger.getLogger("RunParametersOperation_Logger")
     }
 }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/entity/RunParameters.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/entity/RunParameters.kt
@@ -1,0 +1,20 @@
+package com.apexdevs.backend.persistence.database.entity
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+/**
+ * RunParameters document for storing in the database
+ *
+ * @param id unique identifier
+ * @param minSteps the highest allowed minimum step value
+ * @param maxSteps the highest allowed maximum step value
+ * @param maxDuration the highest allowed maximum run duration value
+ * @param numberOfSolutions the highest allowed number of solutions value
+ */
+@Document
+class RunParameters(@Id val id: ObjectId, var minSteps: Int, var maxSteps: Int, var maxDuration: Int, var numberOfSolutions: Int) {
+    constructor(minSteps: Int, maxSteps: Int, maxDuration: Int, numberOfSolutions: Int) :
+        this(ObjectId.get(), minSteps, maxSteps, maxDuration, numberOfSolutions)
+}

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/entity/RunParameters.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/entity/RunParameters.kt
@@ -9,13 +9,13 @@ import org.springframework.data.mongodb.core.mapping.Document
  * They define the upper limit of the run parameter values when running APE.
  *
  * @param id unique identifier
- * @param minSteps the highest allowed minimum step value
- * @param maxSteps the highest allowed maximum step value
+ * @param minLength the highest allowed minimum step value
+ * @param maxLength the highest allowed maximum step value
  * @param maxDuration the highest allowed maximum run duration value
- * @param numberOfSolutions the highest allowed number of solutions value
+ * @param solutions the highest allowed number of solutions value
  */
 @Document
-class RunParameters(@Id val id: ObjectId, var minSteps: Int, var maxSteps: Int, var maxDuration: Int, var numberOfSolutions: Int) {
+class RunParameters(@Id val id: ObjectId, var minLength: Int, var maxLength: Int, var maxDuration: Int, var solutions: Int) {
     /**
      * Constructor to create RunParameters using default values
      */
@@ -24,11 +24,11 @@ class RunParameters(@Id val id: ObjectId, var minSteps: Int, var maxSteps: Int, 
 
     /**
      * Constructor to create RunParameters using custom values
-     * @param minSteps the highest allowed minimum step value
-     * @param maxSteps the highest allowed maximum step value
+     * @param minLength the highest allowed minimum step value
+     * @param maxLength the highest allowed maximum step value
      * @param maxDuration the highest allowed maximum run duration value
-     * @param numberOfSolutions the highest allowed number of solutions value
+     * @param solutions the highest allowed number of solutions value
      */
-    constructor(minSteps: Int, maxSteps: Int, maxDuration: Int, numberOfSolutions: Int) :
-        this(ObjectId.get(), minSteps, maxSteps, maxDuration, numberOfSolutions)
+    constructor(minLength: Int, maxLength: Int, maxDuration: Int, solutions: Int) :
+        this(ObjectId.get(), minLength, maxLength, maxDuration, solutions)
 }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/entity/RunParameters.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/entity/RunParameters.kt
@@ -5,7 +5,8 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
 /**
- * RunParameters document for storing in the database
+ * RunParameters document for storing in the database.
+ * They define the upper limit of the run parameter values when running APE.
  *
  * @param id unique identifier
  * @param minSteps the highest allowed minimum step value
@@ -15,6 +16,19 @@ import org.springframework.data.mongodb.core.mapping.Document
  */
 @Document
 class RunParameters(@Id val id: ObjectId, var minSteps: Int, var maxSteps: Int, var maxDuration: Int, var numberOfSolutions: Int) {
+    /**
+     * Constructor to create RunParameters using default values
+     */
+    constructor() :
+        this(ObjectId.get(), 30, 30, 600, 100)
+
+    /**
+     * Constructor to create RunParameters using custom values
+     * @param minSteps the highest allowed minimum step value
+     * @param maxSteps the highest allowed maximum step value
+     * @param maxDuration the highest allowed maximum run duration value
+     * @param numberOfSolutions the highest allowed number of solutions value
+     */
     constructor(minSteps: Int, maxSteps: Int, maxDuration: Int, numberOfSolutions: Int) :
         this(ObjectId.get(), minSteps, maxSteps, maxDuration, numberOfSolutions)
 }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/repository/RunParametersRepository.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/repository/RunParametersRepository.kt
@@ -1,0 +1,9 @@
+package com.apexdevs.backend.persistence.database.repository
+
+import com.apexdevs.backend.persistence.database.entity.RunParameters
+import org.bson.types.ObjectId
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RunParametersRepository : MongoRepository<RunParameters, ObjectId>

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/GlobalRunParametersNotFoundException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/GlobalRunParametersNotFoundException.kt
@@ -1,6 +1,0 @@
-package com.apexdevs.backend.persistence.exception
-
-/**
- * Exception when the global run parameters settings are not found.
- */
-class GlobalRunParametersNotFoundException(val from: Any, message: String) : RuntimeException(message)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/GlobalRunParametersNotFoundException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/GlobalRunParametersNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.apexdevs.backend.persistence.exception
+
+/**
+ * Exception when the global run parameters settings are not found.
+ */
+class GlobalRunParametersNotFoundException(val from: Any, message: String) : RuntimeException(message)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersExceedLimitsException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersExceedLimitsException.kt
@@ -1,0 +1,6 @@
+package com.apexdevs.backend.persistence.exception
+
+/**
+ * When the run parameters of a workflow run request exceed the configured limits.
+ */
+class RunParametersExceedLimitsException(val from: Any, message: String) : RuntimeException(message)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersNotFoundException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersNotFoundException.kt
@@ -3,6 +3,6 @@ package com.apexdevs.backend.persistence.exception
 import org.bson.types.ObjectId
 
 /**
- * Settings when a certain run parameters settings entry is not found.
+ * When a certain run parameters settings entry is not found.
  */
 class RunParametersNotFoundException(val from: Any, val runParametersId: ObjectId, message: String) : RuntimeException(message)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersNotFoundException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.apexdevs.backend.persistence.exception
+
+import org.bson.types.ObjectId
+
+class RunParametersNotFoundException(val from: Any, val runParametersId: ObjectId, message: String) : RuntimeException(message)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersNotFoundException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/RunParametersNotFoundException.kt
@@ -2,4 +2,7 @@ package com.apexdevs.backend.persistence.exception
 
 import org.bson.types.ObjectId
 
+/**
+ * Settings when a certain run parameters settings entry is not found.
+ */
 class RunParametersNotFoundException(val from: Any, val runParametersId: ObjectId, message: String) : RuntimeException(message)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminController.kt
@@ -141,8 +141,9 @@ class ApiAdminController(val userOperation: UserOperation, val topicOperation: T
         @RequestBody runParametersUploadRequest: RunParametersUploadRequest
     ): RunParametersDetails {
         try {
+            // Check if the user is an administrator
             if (!userOperation.userIsAdmin(admin.username))
-                throw AccessDeniedException("User: ${admin.username} not allowed to access this route")
+                throw AccessDeniedException("User: ${admin.username} is not allowed to access this route")
             val user = userOperation.getByEmail(admin.username)
 
             val newRunParameters = RunParameters(

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminController.kt
@@ -147,10 +147,10 @@ class ApiAdminController(val userOperation: UserOperation, val topicOperation: T
 
             val newRunParameters = RunParameters(
                 id,
-                runParametersUploadRequest.minSteps,
-                runParametersUploadRequest.maxSteps,
+                runParametersUploadRequest.minLength,
+                runParametersUploadRequest.maxLength,
                 runParametersUploadRequest.maxDuration,
-                runParametersUploadRequest.numberOfSolutions
+                runParametersUploadRequest.solutions
             )
 
             return try {

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowController.kt
@@ -13,6 +13,7 @@ import com.apexdevs.backend.ape.entity.workflow.TotalConfig
 import com.apexdevs.backend.ape.entity.workflow.WorkflowOutput
 import com.apexdevs.backend.persistence.UserOperation
 import com.apexdevs.backend.persistence.database.entity.UserStatus
+import com.apexdevs.backend.persistence.exception.RunParametersExceedLimitsException
 import com.apexdevs.backend.persistence.filesystem.FileTypes
 import com.apexdevs.backend.persistence.filesystem.StorageService
 import org.json.JSONObject
@@ -41,8 +42,11 @@ import javax.servlet.http.HttpSession
  */
 @RestController
 @RequestMapping("/api/workflow")
-class ApiWorkflowController(val apeRequestFactory: ApeRequestFactory, val storageService: StorageService, val userOperation: UserOperation) {
-
+class ApiWorkflowController(
+    val apeRequestFactory: ApeRequestFactory,
+    val storageService: StorageService,
+    val userOperation: UserOperation
+) {
     /**
      * @Return: workflow input and output data
      */
@@ -146,6 +150,8 @@ class ApiWorkflowController(val apeRequestFactory: ApeRequestFactory, val storag
             when (exc) {
                 is IllegalArgumentException ->
                     throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Not enough rights for provided run parameters", exc)
+                is RunParametersExceedLimitsException ->
+                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, exc.message, exc)
                 else ->
                     throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
             }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersDetails.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersDetails.kt
@@ -5,8 +5,8 @@ package com.apexdevs.backend.web.controller.entity.runparameters
  */
 data class RunParametersDetails(
     val id: String,
-    val minSteps: String,
-    val maxSteps: String,
+    val minLength: String,
+    val maxLength: String,
     val maxDuration: String,
-    val numberOfSolutions: String
+    val solutions: String
 )

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersDetails.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersDetails.kt
@@ -1,0 +1,12 @@
+package com.apexdevs.backend.web.controller.entity.runparameters
+
+/**
+ * Used to send run parameters information to the front-end.
+ */
+data class RunParametersDetails(
+    val id: String,
+    val minSteps: String,
+    val maxSteps: String,
+    val maxDuration: String,
+    val numberOfSolutions: String
+)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersUploadRequest.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersUploadRequest.kt
@@ -2,9 +2,9 @@ package com.apexdevs.backend.web.controller.entity.runparameters
 
 /**
  * Class with all required fields for run parameters
- * @param minSteps the highest allowed minimum step value
- * @param maxSteps the highest allowed maximum step value
+ * @param minLength the highest allowed minimum step value
+ * @param maxLength the highest allowed maximum step value
  * @param maxDuration the highest allowed maximum run duration value
- * @param numberOfSolutions the highest allowed number of solutions value
+ * @param solutions the highest allowed number of solutions value
  */
-data class RunParametersUploadRequest(val minSteps: Int, val maxSteps: Int, val maxDuration: Int, val numberOfSolutions: Int)
+data class RunParametersUploadRequest(val minLength: Int, val maxLength: Int, val maxDuration: Int, val solutions: Int)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersUploadRequest.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/runparameters/RunParametersUploadRequest.kt
@@ -1,0 +1,10 @@
+package com.apexdevs.backend.web.controller.entity.runparameters
+
+/**
+ * Class with all required fields for run parameters
+ * @param minSteps the highest allowed minimum step value
+ * @param maxSteps the highest allowed maximum step value
+ * @param maxDuration the highest allowed maximum run duration value
+ * @param numberOfSolutions the highest allowed number of solutions value
+ */
+data class RunParametersUploadRequest(val minSteps: Int, val maxSteps: Int, val maxDuration: Int, val numberOfSolutions: Int)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/RunParametersController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/RunParametersController.kt
@@ -1,0 +1,46 @@
+package com.apexdevs.backend.web.controller.routing
+
+import com.apexdevs.backend.persistence.RunParametersOperation
+import com.apexdevs.backend.persistence.database.entity.RunParameters
+import com.apexdevs.backend.persistence.exception.GlobalRunParametersNotFoundException
+import com.apexdevs.backend.web.controller.entity.runparameters.RunParametersDetails
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.logging.Logger
+
+@RestController
+@RequestMapping("/runparameters")
+class RunParametersController(private val runParametersOperation: RunParametersOperation) {
+    /**
+     * Returns the global run parameters settings
+     * @return The run parameters settings
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/")
+    fun getRunGlobalParameters(): RunParametersDetails {
+        return try {
+            val runParameters = runParametersOperation.getGlobalRunParameters()
+            runParametersOperation.getRunParametersDetails(runParameters)
+        } catch (exc: Exception) {
+            when (exc) {
+                is GlobalRunParametersNotFoundException -> {
+                    // Global run parameters settings didn't exist before, create it with default settings
+                    log.info("No global run parameters settings found: creating them using default values.")
+                    runParametersOperation.getRunParametersDetails(
+                        runParametersOperation.createRunParameters(RunParameters())
+                    )
+                }
+                else ->
+                    throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
+            }
+        }
+    }
+
+    companion object {
+        val log: Logger = Logger.getLogger("ApiAdminController_Logger")
+    }
+}

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/RunParametersController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/RunParametersController.kt
@@ -1,8 +1,6 @@
 package com.apexdevs.backend.web.controller.routing
 
 import com.apexdevs.backend.persistence.RunParametersOperation
-import com.apexdevs.backend.persistence.database.entity.RunParameters
-import com.apexdevs.backend.persistence.exception.GlobalRunParametersNotFoundException
 import com.apexdevs.backend.web.controller.entity.runparameters.RunParametersDetails
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,21 +24,11 @@ class RunParametersController(private val runParametersOperation: RunParametersO
             val runParameters = runParametersOperation.getGlobalRunParameters()
             runParametersOperation.getRunParametersDetails(runParameters)
         } catch (exc: Exception) {
-            when (exc) {
-                is GlobalRunParametersNotFoundException -> {
-                    // Global run parameters settings didn't exist before, create it with default settings
-                    log.info("No global run parameters settings found: creating them using default values.")
-                    runParametersOperation.getRunParametersDetails(
-                        runParametersOperation.createRunParameters(RunParameters())
-                    )
-                }
-                else ->
-                    throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
-            }
+            throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
         }
     }
 
     companion object {
-        val log: Logger = Logger.getLogger("ApiAdminController_Logger")
+        val log: Logger = Logger.getLogger("RunParametersController_Logger")
     }
 }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/security/SecurityHttpConfig.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/security/SecurityHttpConfig.kt
@@ -89,6 +89,7 @@ class SecurityHttpConfig(val userDetailsService: UserDetailsService, val passwor
             .antMatchers(HttpMethod.GET, "/api/workflow/**").permitAll()
             .antMatchers(HttpMethod.GET, "/api/domain/download/**").permitAll()
             .antMatchers(HttpMethod.PATCH, "/domain/**").hasRole("USER")
+            .antMatchers(HttpMethod.GET, "/runparameters/**").permitAll()
 
             // public api paths
             .antMatchers(HttpMethod.POST, "/api/domain/upload").hasRole("USER")

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/security/SecurityHttpConfig.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/security/SecurityHttpConfig.kt
@@ -97,6 +97,7 @@ class SecurityHttpConfig(val userDetailsService: UserDetailsService, val passwor
             .antMatchers(HttpMethod.POST, "/api/user/login", "/api/user/register").permitAll()
             .antMatchers(HttpMethod.GET, "/api/admin/**").hasRole("ADMIN")
             .antMatchers(HttpMethod.POST, "/api/admin/**").hasRole("ADMIN")
+            .antMatchers(HttpMethod.PUT, "/api/admin/**").hasRole("ADMIN")
 
             // the rest is authenticated
             .and()

--- a/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestFactoryTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestFactoryTest.kt
@@ -4,6 +4,7 @@
  */
 package com.apexdevs.backend.ape
 
+import com.apexdevs.backend.persistence.RunParametersOperation
 import com.apexdevs.backend.persistence.database.entity.Domain
 import com.apexdevs.backend.persistence.database.entity.DomainVisibility
 import com.apexdevs.backend.persistence.filesystem.FileService
@@ -21,8 +22,9 @@ import org.junit.jupiter.api.assertThrows
 internal class ApeRequestFactoryTest() {
 
     private val storageService = mockk<FileService>()
+    private val runParametersOperation = mockk<RunParametersOperation>()
 
-    private var apeRequestFactory = spyk(ApeRequestFactory(storageService))
+    private var apeRequestFactory = spyk(ApeRequestFactory(storageService, runParametersOperation))
 
     private val test = "Test"
 

--- a/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestTest.kt
@@ -12,8 +12,10 @@ import com.apexdevs.backend.ape.entity.workflow.ParsedModuleNode
 import com.apexdevs.backend.ape.entity.workflow.ParsedTypeNode
 import com.apexdevs.backend.ape.entity.workflow.RunConfig
 import com.apexdevs.backend.ape.entity.workflow.WorkflowOutput
+import com.apexdevs.backend.persistence.RunParametersOperation
 import com.apexdevs.backend.persistence.database.entity.Domain
 import com.apexdevs.backend.persistence.database.entity.DomainVisibility
+import com.apexdevs.backend.persistence.database.entity.RunParameters
 import io.mockk.every
 import io.mockk.mockk
 import nl.uu.cs.ape.sat.APE
@@ -39,6 +41,7 @@ internal class ApeRequestTest {
     private val ape = mockk<APE>()
     private val mockDomainSetup = mockk<APEDomainSetup>()
     private val mockPath = mockk<Path>()
+    private val runParametersOperation = mockk<RunParametersOperation>()
     private val domain = Domain("test", "test", "test", DomainVisibility.Public, "test", "test", listOf("test"), true)
 
     private val inputData = InputData(
@@ -51,7 +54,7 @@ internal class ApeRequestTest {
         solutions = 1
     )
 
-    private val apeRequest = ApeRequest(domain, mockPath, ape)
+    private val apeRequest = ApeRequest(domain, mockPath, ape, runParametersOperation)
 
     @Test
     fun getWorkflows() {
@@ -79,6 +82,11 @@ internal class ApeRequestTest {
         every { mockModuleNode.nodeLabel } returns "Test"
         every { mockModuleNode.inputTypes } returns listOf(mockTypeNode)
         every { mockModuleNode.outputTypes } returns listOf(mockTypeNode)
+        every { runParametersOperation.getGlobalRunParameters() } returns RunParameters()
+        every { mockConfig.solutionMinLength } returns 30
+        every { mockConfig.solutionMaxLength } returns 30
+        every { mockConfig.maxDuration } returns 600
+        every { mockConfig.maxSolutionsToReturn } returns 100
 
         val expectedInOutStates = listOf(ParsedTypeNode("Test", "Test"))
         val expectedModule = listOf(ParsedModuleNode("Test", "Test", expectedInOutStates, expectedInOutStates))
@@ -101,6 +109,11 @@ internal class ApeRequestTest {
         every { mockSolutionList.numberOfSolutions } returns 1
         every { mockSolutionList.get(any()) } returns mockSolutionWorkflow
         every { mockSolutionWorkflow.moduleNodes.size } returns 0
+        every { runParametersOperation.getGlobalRunParameters() } returns RunParameters()
+        every { mockConfig.solutionMinLength } returns 30
+        every { mockConfig.solutionMaxLength } returns 30
+        every { mockConfig.maxDuration } returns 600
+        every { mockConfig.maxSolutionsToReturn } returns 100
 
         val expected = mutableListOf<WorkflowOutput>()
         assertEquals(expected, apeRequest.getWorkflows(mockConfig))

--- a/back-end/src/test/kotlin/com/apexdevs/backend/persistence/RunParametersOperationTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/persistence/RunParametersOperationTest.kt
@@ -1,0 +1,109 @@
+package com.apexdevs.backend.persistence
+
+import com.apexdevs.backend.persistence.database.entity.RunParameters
+import com.apexdevs.backend.persistence.database.repository.RunParametersRepository
+import com.apexdevs.backend.persistence.exception.RunParametersNotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.bson.types.ObjectId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Optional
+
+@DisplayName("Database RunParametersOperation tests")
+class RunParametersOperationTest {
+    /**
+     * Method: createRunParameters
+     */
+    @Test
+    fun `Assert create run parameters inserts correct values`() {
+        // create mocks
+        val runParametersRepository = mockk<RunParametersRepository>()
+
+        // create instance with mocks
+        val runParametersOperation = RunParametersOperation(runParametersRepository)
+
+        // set mocking returns and captures
+        val runParametersSlot = slot<RunParameters>()
+        every { runParametersRepository.insert(capture(runParametersSlot)) } answers
+            { runParametersSlot.captured }
+
+        // perform method
+        val runParameters = RunParameters()
+        runParametersOperation.createRunParameters(runParameters)
+
+        // check results
+        assert(runParametersSlot.isCaptured)
+        assert(runParametersSlot.captured == runParameters)
+    }
+
+    /**
+     * Method: getRunParameters
+     */
+    @Test
+    fun `Assert get run parameters returns correct run parameters`() {
+        // create mocks
+        val runParametersRepository = mockk<RunParametersRepository>()
+
+        // create instance with mocks
+        val runParametersOperation = RunParametersOperation(runParametersRepository)
+
+        // set mocking returns and captures
+        val runParameters = RunParameters()
+        every { runParametersRepository.findById(any()) } returns
+            Optional.of(runParameters)
+
+        val returned = runParametersOperation.getRunParameters(runParameters.id)
+
+        // check results
+        assert(returned == runParameters)
+    }
+
+    /**
+     * Method: getRunParameters
+     */
+    @Test
+    fun `Assert get run parameters throws if not found`() {
+        // create mocks
+        val runParametersRepository = mockk<RunParametersRepository>()
+
+        // create instance with mocks
+        val runParametersOperation = RunParametersOperation(runParametersRepository)
+
+        // set mocking returns and captures
+        val runParameters = RunParameters()
+        every { runParametersRepository.findById(any()) } returns
+            Optional.empty()
+
+        assertThrows<RunParametersNotFoundException> {
+            runParametersOperation.getRunParameters(runParameters.id)
+        }
+    }
+
+    /**
+     * Method: getGlobalRunParameters
+     */
+    @Test
+    fun `Assert get global run parameters returns correct run parameters`() {
+        // create mocks
+        val runParametersRepository = mockk<RunParametersRepository>()
+
+        // create instance with mocks
+        val runParametersOperation = RunParametersOperation(runParametersRepository)
+
+        // set mocking returns and captures
+        val runParameters1 = RunParameters(ObjectId.get(), 100, 100, 6000, 100)
+        val runParameters2 = RunParameters()
+        every { runParametersRepository.findAll() } returns
+            listOf(runParameters1, runParameters2)
+
+        // perform method
+        val returned = runParametersOperation.getGlobalRunParameters()
+
+        // check results
+        assert(returned == runParameters1)
+        assert(returned != runParameters2)
+    }
+}

--- a/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminControllerMVCTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminControllerMVCTest.kt
@@ -4,6 +4,7 @@
  */
 package com.apexdevs.backend.web.controller.api
 
+import com.apexdevs.backend.persistence.RunParametersOperation
 import com.apexdevs.backend.persistence.TopicOperation
 import com.apexdevs.backend.persistence.UserOperation
 import com.apexdevs.backend.persistence.database.entity.UserRequest
@@ -53,6 +54,9 @@ internal class ApiAdminControllerMVCTest(@Autowired val context: WebApplicationC
 
     @MockkBean(relaxed = true)
     private lateinit var topicOperation: TopicOperation
+
+    @MockkBean(relaxed = true)
+    private lateinit var runParametersOperation: RunParametersOperation
 
     @Test
     @WithUserDetails("admin@test.test")

--- a/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminControllerTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiAdminControllerTest.kt
@@ -4,6 +4,7 @@
  */
 package com.apexdevs.backend.web.controller.api
 
+import com.apexdevs.backend.persistence.RunParametersOperation
 import com.apexdevs.backend.persistence.TopicOperation
 import com.apexdevs.backend.persistence.UserOperation
 import com.apexdevs.backend.persistence.database.entity.UserRequest
@@ -32,8 +33,9 @@ internal class ApiAdminControllerTest {
 
     private val mockUserOperation = mockk<UserOperation>()
     private val mockTopicOperation = mockk<TopicOperation>()
+    private val mockRunParametersOperation = mockk<RunParametersOperation>()
     private val mockAdmin = mockk<User>()
-    private val apiAdminController = ApiAdminController(mockUserOperation, mockTopicOperation)
+    private val apiAdminController = ApiAdminController(mockUserOperation, mockTopicOperation, mockRunParametersOperation)
 
     @BeforeAll
     fun init() {

--- a/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowControllerTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowControllerTest.kt
@@ -32,13 +32,17 @@ import javax.servlet.http.HttpSession
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ApiWorkflowControllerTest() {
 
-    private val userOperation = mockk<UserOperation>()
     private val apeRequestFactory = mockk<ApeRequestFactory>(relaxed = true)
     private val storageService = mockk<StorageService>()
+    private val userOperation = mockk<UserOperation>()
     private val apeRequest = mockk<ApeRequest>()
     private val domain = mockk<Domain>()
 
-    private val apiWorkflowController = ApiWorkflowController(apeRequestFactory, storageService, userOperation)
+    private val apiWorkflowController = ApiWorkflowController(
+        apeRequestFactory,
+        storageService,
+        userOperation
+    )
     private val test = "Test"
     private val id = ObjectId()
     private val session = mockk<HttpSession>()

--- a/front-end/src/components/Admin/RunParametersConfig.module.scss
+++ b/front-end/src/components/Admin/RunParametersConfig.module.scss
@@ -1,0 +1,18 @@
+@import '../../styles/globals.scss';
+
+.Form {
+  max-width: 500px;
+}
+
+.Label {
+  background-color: $background-color;
+  padding: 5px;
+  border-radius: 4px;
+  margin-bottom: 6px;
+}
+
+.Input {
+  text-align: right;
+  width: 80px;
+  margin-left: calc(100% - 80px);
+}

--- a/front-end/src/components/Admin/RunParametersConfig.tsx
+++ b/front-end/src/components/Admin/RunParametersConfig.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { RunOptions } from '@models/workflow/Workflow';
+import { Button, Card, Form, Input, InputNumber, message } from 'antd';
+import styles from './RunParametersConfig.module.scss';
+
+/**
+ * The props for {@link RunParametersConfig}.
+ */
+interface RunParametersConfigProps {
+  /** The current run parameters configuration. */
+  runParameters: RunOptions;
+}
+
+/**
+ * Component for configuring the global run parameters limits.
+ */
+export function RunParametersConfig(props: RunParametersConfigProps) {
+  const { runParameters } = props;
+
+  /**
+   * POST the updated run parameters configuration.
+   * @param values The new configuration.
+   */
+  function postRunParameters(values: RunOptions) {
+    const endpoint: string = `${process.env.NEXT_PUBLIC_FE_URL}/api/admin/runparameters/${values.id}`;
+    fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(values),
+    })
+      .then((res) => {
+        // Success
+        if (res.status === 200) {
+          message.success('Updated the run parameters.');
+          return;
+        }
+        // Fail
+        message.error('Failed to update the run parameters!');
+      });
+  }
+
+  return (
+    <Card>
+      <Form
+        className={styles.Form}
+        labelCol={{ span: 8 }}
+        wrapperCol={{ span: 16 }}
+        initialValues={runParameters}
+        onFinish={postRunParameters}
+      >
+        <Form.Item
+          name="id"
+          hidden={true}
+        >
+          <Input />
+        </Form.Item>
+
+        <Form.Item
+          className={styles.Label}
+          label="Min steps"
+          labelAlign="left"
+          name="minLength"
+        >
+          <InputNumber
+            className={styles.Input}
+          />
+        </Form.Item>
+
+        <Form.Item
+          className={styles.Label}
+          label="Max steps"
+          labelAlign="left"
+          name="maxLength"
+        >
+          <InputNumber
+            className={styles.Input}
+          />
+        </Form.Item>
+
+        <Form.Item
+          className={styles.Label}
+          label="Max duration (s)"
+          labelAlign="left"
+          name="maxDuration"
+        >
+          <InputNumber
+            className={styles.Input}
+          />
+        </Form.Item>
+
+        <Form.Item
+          className={styles.Label}
+          label="Number of solutions"
+          labelAlign="left"
+          name="solutions"
+        >
+          <InputNumber
+            className={styles.Input}
+          />
+        </Form.Item>
+
+        <Form.Item>
+          <Button type="primary" htmlType="submit">Save</Button>
+        </Form.Item>
+      </Form>
+    </Card>
+  );
+}
+
+export default RunParametersConfig;

--- a/front-end/src/components/WorkflowInput/DataSelector.tsx
+++ b/front-end/src/components/WorkflowInput/DataSelector.tsx
@@ -35,9 +35,9 @@ function DataSelector(props: DataSelectorProps) {
       {
         dataOntology.roots.map((root, index) => (
           <label key={root.label} style={{ display: 'flex' }}>
-            <text className={styles[getClassName(index)]}>
+            <div className={styles[getClassName(index)]}>
               {root.label}:
-            </text>
+            </div>
             <OntologyTreeSelect
               ontology={root}
               value={data.values[index]}

--- a/front-end/src/components/WorkflowInput/WorkflowInput.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.tsx
@@ -562,17 +562,22 @@ class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputSta
     })
       .then((res) => {
         if (!res.ok) {
-          return Promise.resolve(message.error('Something went wrong :('));
+          return Promise.reject(res.json());
         }
         return res.json();
       })
-      .then((workflows) => {
-        if (workflows && workflows.length > 0) {
-          return Promise.resolve(onRun(workflows));
+      .then((data) => {
+        if (data && data.length > 0) {
+          return Promise.resolve(onRun(data));
         }
         return Promise.resolve(message.warning('APE could not find any results'));
       })
-      .catch((error) => console.error('Workflow error', error));
+      .catch((error) => {
+        // Await error parsing
+        error.then((data: any) => {
+          message.error(data.message, 5);
+        });
+      });
   };
 
   /**

--- a/front-end/src/components/WorkflowInput/WorkflowInput.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.tsx
@@ -589,7 +589,7 @@ class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputSta
       constraints,
       maxLength: runOptions.maxLength,
       minLength: runOptions.minLength,
-      maxDuration: runOptions.maxLength,
+      maxDuration: runOptions.maxDuration,
       solutions: runOptions.solutions,
     };
     const base = process.env.NEXT_PUBLIC_BASE_URL;

--- a/front-end/src/components/WorkflowInput/WorkflowInput.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.tsx
@@ -126,6 +126,7 @@ class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputSta
       importModalEnabled: false,
       downloadModalEnabled: false,
       runOptions: {
+        id: 'noid',
         maxDuration: 10,
         solutions: 10,
         minLength: 1,

--- a/front-end/src/components/WorkflowInput/WorkflowInput.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.tsx
@@ -841,7 +841,7 @@ class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputSta
    * Updates the run options
    * @param changed updated run options
    */
-  updateRunOptions = (changed) => {
+  updateRunOptions = (changed: RunOptions) => {
     /*
      * Handle each changed field, there can be more than one changed
      * if the the predicate min <= max if violated.

--- a/front-end/src/components/WorkflowInput/WorkflowRun.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowRun.tsx
@@ -23,6 +23,8 @@ interface WorkflowRunProps {
   formRef: RefObject<FormInstance>;
   /** Function to manually update run options */
   updateRunOptions: (any) => void;
+  /** The run parameters limits */
+  runParametersLimits: RunOptions;
 }
 
 /** State of the WorkflowRun component */
@@ -38,23 +40,6 @@ interface WorkflowRunState {
  * The parent component should handle further actions.
  */
 class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
-  /**
-   * The limits on the run parameters. It would be better to fetch them from
-   * the back-end than to hardcode them.
-   */
-  static runParameterLimits = {
-    /** The lower bound to the minimum length */
-    minLength: 0,
-    /** The lower bound to the duration */
-    minDuration: 10,
-    /** The lower bound to the number of solutions */
-    minSolutions: 0,
-    /** The upper bound to the number of solutions */
-    maxSolutions: 100,
-  };
-
-  /** FormRef imported to allow code-based changes of the form values. */
-
   constructor(props: WorkflowRunProps) {
     super(props);
 
@@ -87,7 +72,7 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
 
   render() {
     const { loading } = this.state;
-    const { runOptions: options, formRef } = this.props;
+    const { runOptions: options, formRef, runParametersLimits } = this.props;
     return (
       <div className={styles.Box} id="Run">
         <Card
@@ -124,8 +109,8 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
             <Form.Item name="minLength" label="Min steps" className={Styles.Label}>
               <InputNumber
                 id="minLength"
-                min={WorkflowRun.runParameterLimits.minLength}
-                max={options.maxLength}
+                min={0}
+                max={runParametersLimits.minLength}
                 className={Styles.Input}
               />
             </Form.Item>
@@ -133,7 +118,8 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
             <Form.Item name="maxLength" label="Max steps" className={Styles.Label}>
               <InputNumber
                 id="maxLength"
-                min={options.minLength}
+                min={0}
+                max={runParametersLimits.maxLength}
                 className={Styles.Input}
               />
             </Form.Item>
@@ -141,7 +127,8 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
             <Form.Item name="maxDuration" label="Max duration (s)" className={Styles.Label}>
               <InputNumber
                 id="maxDuration"
-                min={WorkflowRun.runParameterLimits.minDuration}
+                min={0}
+                max={runParametersLimits.maxDuration}
                 className={Styles.Input}
               />
             </Form.Item>
@@ -149,8 +136,8 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
             <Form.Item name="solutions" label="Number of solutions" className={Styles.Label} labelAlign="right">
               <InputNumber
                 id="solutions"
-                min={WorkflowRun.runParameterLimits.minSolutions}
-                max={WorkflowRun.runParameterLimits.maxSolutions}
+                min={0}
+                max={runParametersLimits.solutions}
                 className={Styles.Input}
               />
             </Form.Item>

--- a/front-end/src/components/WorkflowInput/WorkflowRun.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowRun.tsx
@@ -22,7 +22,7 @@ interface WorkflowRunProps {
   /** The formRef object to allow updates */
   formRef: RefObject<FormInstance>;
   /** Function to manually update run options */
-  updateRunOptions: (any) => void;
+  updateRunOptions: (runOptions: RunOptions) => void;
   /** The run parameters limits */
   runParametersLimits: RunOptions;
 }
@@ -65,7 +65,7 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
    * Update the state when a run option field's value is changed.
    * @param changed The changed field with value
    */
-  onChange = (changed: any) => {
+  onChange = (changed: RunOptions) => {
     const { updateRunOptions } = this.props;
     updateRunOptions(changed);
   };

--- a/front-end/src/models/workflow/Workflow.tsx
+++ b/front-end/src/models/workflow/Workflow.tsx
@@ -89,15 +89,19 @@ interface Constraint {
   parameters: (Data | Tool)[];
 }
 
-/** Interface for the run options */
+/**
+ * Interface for the run options / run parameters
+ */
 interface RunOptions {
-  /** The maximum run time of the query */
+  /** The ID of the run options. */
+  id: string;
+  /** The maximum run time of the query. */
   maxDuration: number;
-  /** The (maximum) number of solutions */
+  /** The (maximum) number of solutions. */
   solutions: number;
-  /** The minimal length of a solution */
+  /** The minimal length of a solution. */
   minLength: number;
-  /** The maximum length of a solution */
+  /** The maximum length of a solution. */
   maxLength: number;
 }
 

--- a/front-end/src/pages/admin.tsx
+++ b/front-end/src/pages/admin.tsx
@@ -135,15 +135,15 @@ class AdminPage extends React.Component<IProps, IState> {
               <title>Administration | APE</title>
             </Head>
             <div className={styles.section}>
-              <Title>Topics</Title>
+              <Title level={2}>Topics</Title>
               <TopicCreate />
             </div>
             <div className={styles.section}>
-              <Title>Approvals</Title>
+              <Title level={2}>Approvals</Title>
               <Approval approvalRequests={requests} postUserStatus={this.postUserStatus} />
             </div>
             <div className={styles.section}>
-              <Title>Run parameters configuration</Title>
+              <Title level={2}>Run parameters configuration</Title>
               <RunParametersConfig runParameters={runParameters} />
             </div>
           </div>

--- a/front-end/src/pages/admin.tsx
+++ b/front-end/src/pages/admin.tsx
@@ -12,6 +12,8 @@ import Approval from '@components/Admin/Approval';
 import ApprovalRequest from '@models/ApprovalRequest';
 import { getSession, signIn } from 'next-auth/client';
 import TopicCreate from '@components/Admin/TopicCreate';
+import RunParametersConfig from '@components/Admin/RunParametersConfig';
+import { RunOptions } from '@models/workflow/Workflow';
 import styles from './Admin.module.scss';
 
 const { Title } = Typography;
@@ -22,6 +24,8 @@ interface IState {
 
 interface IProps {
   session: any;
+  /** The current run parameters configuration. */
+  runParameters: RunOptions;
 }
 
 /**
@@ -121,7 +125,7 @@ class AdminPage extends React.Component<IProps, IState> {
 
   render() {
     const { requests } = this.state;
-    const { session } = this.props;
+    const { session, runParameters } = this.props;
 
     if (session && session.user) {
       if (session.user.admin) {
@@ -137,6 +141,10 @@ class AdminPage extends React.Component<IProps, IState> {
             <div className={styles.section}>
               <Title>Approvals</Title>
               <Approval approvalRequests={requests} postUserStatus={this.postUserStatus} />
+            </div>
+            <div className={styles.section}>
+              <Title>Run parameters configuration</Title>
+              <RunParametersConfig runParameters={runParameters} />
             </div>
           </div>
         );
@@ -164,9 +172,20 @@ class AdminPage extends React.Component<IProps, IState> {
 
 export async function getServerSideProps({ req }) {
   const session = await getSession({ req });
+
+  // Get the current run parameters configuration
+  let runParameters: RunOptions;
+  const runParametersEndpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/runparameters/`;
+  await fetch(runParametersEndpoint, {
+    method: 'GET',
+  })
+    .then((response) => response.json())
+    .then((data) => { runParameters = data; });
+
   return {
     props: {
       session,
+      runParameters,
     },
   };
 }

--- a/front-end/src/pages/api/admin/runparameters/[id].tsx
+++ b/front-end/src/pages/api/admin/runparameters/[id].tsx
@@ -1,0 +1,44 @@
+import { getSession } from 'next-auth/client';
+import { RunOptions } from '@models/workflow/Workflow';
+
+/**
+ * Handle PUT requests.
+ * @param res The outgoing response.
+ * @param session The current session.
+ * @param runParameters The run parameters PUT by the front-end.
+ */
+async function handlePUT(res: any, session: any, runParameters: RunOptions) {
+  let status: number = 400;
+
+  const endpoint: string = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/api/admin/runparameters/${runParameters.id}`;
+  await fetch(endpoint, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      cookie: session.user.sessionid,
+    },
+    body: JSON.stringify(runParameters),
+  })
+    .then((response) => { status = response.status; });
+
+  return res.status(status).end();
+}
+
+/**
+ * Handle incoming requests.
+ * @param req The incoming request.
+ * @param res The outgoing response.
+ */
+export default async function handler(req: any, res: any) {
+  const session: any = await getSession({ req });
+  const { method, body } = req;
+
+  switch (method) {
+    case 'PUT':
+      return handlePUT(res, session, body);
+    default:
+      res.setHeader('Allow', ['PUT']);
+      return res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}

--- a/front-end/src/pages/explore/[id].tsx
+++ b/front-end/src/pages/explore/[id].tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import Head from 'next/head';
 import { Layout } from 'antd';
 import Explore from '@components/Explore/Explore';
-import { Ontology, ConstraintType, DataType, OntologyNode } from '@models/workflow/Workflow';
+import { Ontology, ConstraintType, DataType, OntologyNode, RunOptions } from '@models/workflow/Workflow';
 import WorkflowData from '@models/workflow/WorkflowVisualizerData';
 import WorkflowInput from '@components/WorkflowInput/WorkflowInput';
 import Domain from '@models/Domain';
@@ -23,7 +23,9 @@ import { ConstraintsConfig } from '@models/Configuration/ConstraintsConfig';
  */
 interface IExplorePageProps {
   /** The domain to explore */
-  domain: Domain;
+  domain: Domain,
+  /** The run parameters limits from the back-end */
+  runParametersLimits: RunOptions,
 }
 
 /** The state interface for {@link ExplorePage} */
@@ -314,7 +316,7 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
 
   render() {
     const { workflows, data } = this.state;
-    const { domain } = this.props;
+    const { domain, runParametersLimits } = this.props;
     const {
       dataOntology,
       toolOntology,
@@ -339,6 +341,7 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
             useCaseConfig={useCaseConfig}
             useCaseConstraints={useCaseConstraints}
             domain={domain.id}
+            runParametersLimits={runParametersLimits}
           />
         </Layout>
         <div ref={this.workflowViewRef}>
@@ -359,19 +362,26 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
 
 export async function getServerSideProps({ query }) {
   // Get the current domain
-  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/domain/${query.id}/`;
+  const domainEndpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/domain/${query.id}/`;
   let domain: Domain;
-  await fetch(endpoint, {
+  await fetch(domainEndpoint, {
     method: 'GET',
   })
     .then((response) => response.json())
     .then((data) => { domain = data; })
     .catch(() => { domain = query.id; });
 
-  // TODO: remove this line when back-end is updated to include ID
-  domain.id = query.id;
+  // Get the run parameters limits
+  let runParametersLimits: RunOptions;
+  const runParametersEndpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/runparameters/`;
+  await fetch(runParametersEndpoint, {
+    method: 'GET',
+  })
+    .then((response) => response.json())
+    .then((data) => { runParametersLimits = data; });
+
   return {
-    props: { domain },
+    props: { domain, runParametersLimits },
   };
 }
 


### PR DESCRIPTION
Previously, the run parameters limits for running workflows were fixed and could not be easily configured.
- Add run parameters to back-end (database objects, endpoints, etc).
- Front-end gets run parameters from back-end.
- Admin page can be used to configure the run parameters for all domains.
- The back-end checks if a workflow run does not exceed the configured run parameters limits.