### PR TITLE
[FEATURE] Make workflow run error messages more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- More specific error messages are shown when a workflow run / synthesis gets interrupted.
+
 ## [1.1.0] - 2021-05-28
 
 ### Added

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/SynthesisFlagException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/SynthesisFlagException.kt
@@ -1,0 +1,16 @@
+package com.apexdevs.backend.persistence.exception
+
+import nl.uu.cs.ape.sat.models.enums.SynthesisFlag
+
+class SynthesisFlagException(val from: Any, val flag: SynthesisFlag) : RuntimeException(flag.message) {
+    /**
+     * Overrides some of APE's SynthesisFlag messages with user friendly messages which can be shown on the front-end.
+     * @return A user friendly message describing the reason the synthesis was interrupted.
+     */
+    fun getFriendlyMessage(): String {
+        return when (flag) {
+            SynthesisFlag.TIMEOUT -> "Synthesis was interrupted because it reached the max duration."
+            else -> flag.message
+        }
+    }
+}

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowController.kt
@@ -14,6 +14,7 @@ import com.apexdevs.backend.ape.entity.workflow.WorkflowOutput
 import com.apexdevs.backend.persistence.UserOperation
 import com.apexdevs.backend.persistence.database.entity.UserStatus
 import com.apexdevs.backend.persistence.exception.RunParametersExceedLimitsException
+import com.apexdevs.backend.persistence.exception.SynthesisFlagException
 import com.apexdevs.backend.persistence.filesystem.FileTypes
 import com.apexdevs.backend.persistence.filesystem.StorageService
 import org.json.JSONObject
@@ -152,6 +153,8 @@ class ApiWorkflowController(
                     throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Not enough rights for provided run parameters", exc)
                 is RunParametersExceedLimitsException ->
                     throw ResponseStatusException(HttpStatus.BAD_REQUEST, exc.message, exc)
+                is SynthesisFlagException ->
+                    throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, exc.getFriendlyMessage(), exc)
                 else ->
                     throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
             }

--- a/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestTest.kt
@@ -27,6 +27,7 @@ import nl.uu.cs.ape.sat.core.solutionStructure.SolutionWorkflow
 import nl.uu.cs.ape.sat.core.solutionStructure.TypeNode
 import nl.uu.cs.ape.sat.models.AllModules
 import nl.uu.cs.ape.sat.models.AllTypes
+import nl.uu.cs.ape.sat.models.enums.SynthesisFlag
 import nl.uu.cs.ape.sat.models.logic.constructs.TaxonomyPredicate
 import nl.uu.cs.ape.sat.utils.APEDomainSetup
 import org.json.JSONObject
@@ -72,6 +73,7 @@ internal class ApeRequestTest {
         every { mockPath.toString() } returns "Test"
         every { mockSolutionList.numberOfSolutions } returns 1
         every { mockSolutionList.get(any()) } returns mockSolutionWorkflow
+        every { mockSolutionList.flag } returns SynthesisFlag.NONE
         every { mockSolutionWorkflow.moduleNodes.size } returns 1
         every { mockSolutionWorkflow.workflowInputTypeStates } returns listOf(mockTypeNode)
         every { mockSolutionWorkflow.workflowOutputTypeStates } returns listOf(mockTypeNode)
@@ -108,6 +110,7 @@ internal class ApeRequestTest {
         every { mockPath.toString() } returns "Test"
         every { mockSolutionList.numberOfSolutions } returns 1
         every { mockSolutionList.get(any()) } returns mockSolutionWorkflow
+        every { mockSolutionList.flag } returns SynthesisFlag.NONE
         every { mockSolutionWorkflow.moduleNodes.size } returns 0
         every { runParametersOperation.getGlobalRunParameters() } returns RunParameters()
         every { mockConfig.solutionMinLength } returns 30


### PR DESCRIPTION
When a workflow run / synthesis gets interrupted, a generic message was shown. This change makes the error message more specific to help the user identify the issue. The error messages are taken from APE itself, but may be overridden by the back-end to make them more user-friendly.

Summary:
- Make workflow run error messages more specific when the run is interrupted.