### PR TITLE
[FIX] Consistent project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - More specific error messages are shown when a workflow run / synthesis gets interrupted.
 - Change occurrences of "APE Web View" to "APE Web".
+- Moved front-end Docker container from Node.js 12 to Node.js 14.
+- Logging of back-end tests is less verbose (information about the tests themselves is not affected).
+
+### Fixed
+
+- Test application.properties of back-end was in the wrong location.
 
 ## [1.1.0] - 2021-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - More specific error messages are shown when a workflow run / synthesis gets interrupted.
+- Change occurrences of "APE Web View" to "APE Web".
 
 ## [1.1.0] - 2021-05-28
 

--- a/front-end/src/pages/about.tsx
+++ b/front-end/src/pages/about.tsx
@@ -25,7 +25,7 @@ function AboutPage() {
         <Col span={12}>
           <Title>About us</Title>
           <Paragraph>
-            APE Web View is a graphical interface for the <strong>APE library</strong>.
+            APE Web is a graphical interface for the <strong>APE library</strong>.
             APE (Automated Pipeline Explorer) is a command line tool and Java API
             for the automated exploration of possible computational pipelines
             (scientific workflows) from large collections of computational tools.

--- a/front-end/src/pages/contact.tsx
+++ b/front-end/src/pages/contact.tsx
@@ -26,7 +26,7 @@ function ContactPage() {
           <Title>Contact</Title>
           <Paragraph>&nbsp;</Paragraph>
           <Paragraph>
-            For any questions concerning APE and APE Web View you can get in touch with:
+            For any questions concerning APE and APE Web you can get in touch with:
           </Paragraph>
           <ul>
             <li>Vedran Kasalica (<Link href="mailto:v.kasalica@uu.nl">v.kasalica[at]uu.nl</Link>), lead developer</li>

--- a/front-end/src/pages/index.tsx
+++ b/front-end/src/pages/index.tsx
@@ -73,10 +73,10 @@ function DomainsPage({ publicDomains, ownedDomains, sharedDomains, session }: ID
         <title>Home | APE</title>
       </Head>
       <div>
-        <Title>Welcome to APE Web View</Title>
+        <Title>Welcome to APE Web</Title>
         <Paragraph>&nbsp;</Paragraph>
         <Paragraph>
-          APE (Automated Pipeline Explorer) Web View is a graphical interface for the&nbsp;
+          APE (Automated Pipeline Explorer) Web is a graphical interface for the&nbsp;
           <strong>APE library</strong>&nbsp;
           (see <a href="https://github.com/sanctuuary/APE/" target="_blank" rel="noreferrer noopener">GitHub</a>),
           used for the automated exploration of possible computational pipelines
@@ -93,7 +93,7 @@ function DomainsPage({ publicDomains, ownedDomains, sharedDomains, session }: ID
           <a href="https://ape-framework.readthedocs.io/en/latest/" target="_blank" rel="noreferrer noopener">our page</a>.
         </Paragraph>
         <Paragraph>
-          APE Web View allows you to explore and automatically compose
+          APE Web allows you to explore and automatically compose
           these workflows from pre-defined domains
           (such as image manipulation domain using the ImageMagick toolset).
           In addition you are encouraged to create your own domains and share them with other users.

--- a/front-end/src/pages/privacy.tsx
+++ b/front-end/src/pages/privacy.tsx
@@ -23,12 +23,12 @@ function PrivacyPage() {
       <Row>
         <Col span={6} />
         <Col span={12}>
-          <Title>APE Web View Privacy Policy</Title>
+          <Title>APE Web Privacy Policy</Title>
           <Paragraph>
-            At APE WEb View, accessible at ape.science.uu.nl,
+            At APE Web, accessible at ape.science.uu.nl,
             one of our main priorities is the privacy of our visitors.
             This Privacy Policy document contains types of information
-            that is collected and recorded by the APE Web View website and how we use it.
+            that is collected and recorded by the APE Web website and how we use it.
           </Paragraph>
           <Paragraph>
             If you have additional questions or require more information about our Privacy Policy,
@@ -38,7 +38,7 @@ function PrivacyPage() {
           <Paragraph>
             This privacy policy applies only to our online activities and is valid for
             visitors to our website with regards to the information that they shared and/or
-            collect in APE Web View.
+            collect in APE Web.
             This policy is not applicable to any information collected offline
             or via channels other than this website.
           </Paragraph>


### PR DESCRIPTION
There were occurrences where the project was named "APE Web View". These occurrences now say "APE Web" which is consistent with the name of the project.

Summary:
- Change occurrences of "APE Web View" to "APE Web".
- Include missing CHANGELOG information of previous #15 pull request.