### PR TITLE
[CHANGE] No longer include email addresses in UserInfo objects by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change occurrences of "APE Web View" to "APE Web".
 - Moved front-end Docker container from Node.js 12 to Node.js 14.
 - Logging of back-end tests is less verbose (information about the tests themselves is not affected).
+- User's email addresses are no longer included in responses from the back-end by default (previously email addresses were also only given when necessary).
 
 ### Fixed
 

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/user/UserInfo.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/user/UserInfo.kt
@@ -20,12 +20,12 @@ data class UserInfo(val userId: String, var email: String?, val displayName: Str
      * Constructor using User entity from database. Only passes non-security information
      * @param user The user whose information to use.
      * @param isAdmin Whether the user is an administrator.
-     * @param hideMail Whether the email address of the user should be hidden.
+     * @param includeMail Whether the email address of the user should be included.
      */
-    constructor(user: User, isAdmin: Boolean, hideMail: Boolean = false) :
+    constructor(user: User, isAdmin: Boolean, includeMail: Boolean = false) :
         this(user.id.toString(), user.email, user.displayName, user.status, isAdmin) {
-            // hide the user's email address when specified to do so
-            if (hideMail) {
+            // only show the user's email address when explicitly specified
+            if (!includeMail) {
                 this.email = null
             }
         }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
@@ -62,7 +62,7 @@ class UserController(val userOperation: UserOperation) {
             val isAdmin = userOperation.userIsAdmin(userResult.get().email)
 
             // create user info as response
-            return UserInfo(userResult.get(), isAdmin)
+            return UserInfo(userResult.get(), isAdmin, true)
         } catch (exc: Exception) {
             when (exc) {
                 is HttpClientErrorException.BadRequest, is IllegalArgumentException ->
@@ -86,7 +86,7 @@ class UserController(val userOperation: UserOperation) {
                 throw AccessDeniedException("User: ${user.username} is not allowed to access this route")
 
             val users = userOperation.approvedUsers()
-            return users.map { u -> UserInfo(u, userOperation.userIsAdmin(u.email), true) }
+            return users.map { u -> UserInfo(u, userOperation.userIsAdmin(u.email), false) }
         } catch (exc: Exception) {
             when (exc) {
                 is AccessDeniedException ->

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/security/authentication/UsernamePasswordAPISuccessHandler.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/security/authentication/UsernamePasswordAPISuccessHandler.kt
@@ -51,7 +51,7 @@ class UsernamePasswordAPISuccessHandler(val userOperation: UserOperation) : Simp
                     val isAdmin = userOperation.userIsAdmin(principal.username)
 
                     // wrap user result into JSON object
-                    val json = JSONObject.wrap(UserInfo(userResult.get(), isAdmin))
+                    val json = JSONObject.wrap(UserInfo(userResult.get(), isAdmin, true))
                     // write JSON into response
                     response?.writer?.write(json.toString())
                 } else {

--- a/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/entity/user/UserInfoTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/entity/user/UserInfoTest.kt
@@ -16,22 +16,22 @@ internal class UserInfoTest {
         val user = User(ObjectId(), "user@test.test", "test", "test", UserStatus.Approved)
         val userInfo = UserInfo(user, false)
         assertEquals(userInfo.userId, user.id.toString())
-        assertEquals(userInfo.email, user.email)
+        assertNull(userInfo.email)
         assertEquals(userInfo.displayName, user.displayName)
         assertEquals(userInfo.status, user.status)
         assertEquals(userInfo.isAdmin, false)
     }
 
     /**
-     * Test if the constructor with the optional "hideMail" argument works.
+     * Test if the optional "includeEmail" argument works as intended.
      */
     @Test
-    fun hideEmailConstructor() {
+    fun includeEmailConstructor() {
         val user = User(ObjectId(), "user@test.test", "test", "test", UserStatus.Approved)
         val isAdmin = true
         val userInfo = UserInfo(user, isAdmin, true)
         assertEquals(userInfo.userId, user.id.toString())
-        assertNull(userInfo.email)
+        assertEquals(userInfo.email, user.email)
         assertEquals(userInfo.displayName, user.displayName)
         assertEquals(userInfo.status, user.status)
         assertEquals(userInfo.isAdmin, isAdmin)


### PR DESCRIPTION
Previously, the UserInfo class on the back-end would always include the email address of a user unless explicitly specified it should not. This change makes UserInfo hide the user's email address by default, unless explicitly specified it should be included.
User's email addresses were only ever returned when necessary anyway. However, this change should help keeping it that way.

Summary
- UserInfo no longer includes a user's email address by default.