### PR TITLE
[FEATURE] Manage domain access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Component to grant or revoke administrator privileges to / from users.
+- Grant or revoke administrator privileges to / from users in the administrator page.
+- Manage access to a domain in the domain edit page.
 - Endpoint for changing the administrator status of users.
 - (Admin only) endpoint for getting a list of all users.
 - Endpoint to get all users with certain access to a domain.
 - Endpoint to set a user's access to a domain.
-- Component to manage access to a domain.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Admin only) endpoint for getting a list of all users.
 - Endpoint to get all users with certain access to a domain.
 - Endpoint to set a user's access to a domain.
+- Component to manage access to a domain.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Admin only) endpoint for getting a list of all users.
 - Endpoint to get all users with certain access to a domain.
 - Endpoint to set a user's access to a domain.
+- Endpoint to transfer the ownership of a domain.
 
 ### Changed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Test application.properties of back-end was in the wrong location.
+- The 403 result on the domain edit page now redirects to the home page instead of a non-existent page.
 
 ## [1.1.0] - 2021-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add component to grant or revoke administrator privileges to / from users.
-- Add endpoint for changing the administrator status of users.
-- Add (admin only) endpoint for getting a list of all users.
+- Component to grant or revoke administrator privileges to / from users.
+- Endpoint for changing the administrator status of users.
+- (Admin only) endpoint for getting a list of all users.
+- Endpoint to get all users with certain access to a domain.
+- Endpoint to set a user's access to a domain.
 
 ### Changed
 

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/DomainOperation.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/DomainOperation.kt
@@ -23,6 +23,7 @@ import com.apexdevs.backend.persistence.exception.UserNotFoundException
 import com.apexdevs.backend.web.controller.entity.domain.DomainDetails
 import com.apexdevs.backend.web.controller.entity.domain.DomainUploadRequest
 import org.bson.types.ObjectId
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Component
 
 /**

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/DomainOperation.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/DomainOperation.kt
@@ -246,4 +246,18 @@ class DomainOperation(val domainRepository: DomainRepository, val userRepository
         // Return true if user has access rights and these are better or equal to required access rights
         return userAccess.isPresent && userAccess.get().access >= requiredAccess
     }
+
+    /**
+     * Gets all users who have one of the given access levels to a certain domain.
+     * @param domainId The id of the domain to which the users should have access.
+     * @param access The access levels which the users should have.
+     * @return A list of user id's with the access level the users have to the domain.
+     */
+    fun getUsersByDomainAndAccess(domainId: ObjectId, access: List<DomainAccess>): List<UserDomainAccess> {
+        val usersByDomainAndAccess: MutableList<UserDomainAccess> = mutableListOf()
+        for (accessRight in access) {
+            usersByDomainAndAccess += userDomainAccessRepository.findAllByDomainIdAndAccess(domainId, accessRight)
+        }
+        return usersByDomainAndAccess.toList()
+    }
 }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/DomainOperation.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/DomainOperation.kt
@@ -23,7 +23,6 @@ import com.apexdevs.backend.persistence.exception.UserNotFoundException
 import com.apexdevs.backend.web.controller.entity.domain.DomainDetails
 import com.apexdevs.backend.web.controller.entity.domain.DomainUploadRequest
 import org.bson.types.ObjectId
-import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Component
 
 /**

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/collection/DomainCollection.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/collection/DomainCollection.kt
@@ -38,8 +38,8 @@ class DomainCollection(val domainRepository: DomainRepository, val userDomainAcc
      */
     fun getDomainsByUserAndAccess(user: User, access: List<DomainAccess>): List<UserDomainAccess> {
         val domainsByUserAndAccess: MutableList<UserDomainAccess> = mutableListOf()
-        for (accessLevel in access) {
-            domainsByUserAndAccess += userDomainAccessRepository.findAllByUserIdAndAccess(user.id, accessLevel)
+        for (accessRight in access) {
+            domainsByUserAndAccess += userDomainAccessRepository.findAllByUserIdAndAccess(user.id, accessRight)
         }
 
         return domainsByUserAndAccess.toList()

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/repository/UserDomainAccessRepository.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/database/repository/UserDomainAccessRepository.kt
@@ -16,4 +16,5 @@ interface UserDomainAccessRepository : MongoRepository<UserDomainAccess, ObjectI
     fun findByUserIdAndDomainId(userId: ObjectId, domainId: ObjectId): Optional<UserDomainAccess>
     fun findByDomainId(domainId: ObjectId): List<UserDomainAccess>
     fun findAllByUserIdAndAccess(userId: ObjectId, access: DomainAccess): List<UserDomainAccess>
+    fun findAllByDomainIdAndAccess(domainId: ObjectId, access: DomainAccess): List<UserDomainAccess>
 }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiDomainController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiDomainController.kt
@@ -380,9 +380,9 @@ class ApiDomainController(
                 is AccessDeniedException ->
                     throw ResponseStatusException(HttpStatus.FORBIDDEN, exc.message, exc)
                 is DomainNotFoundException ->
-                    throw ResponseStatusException(HttpStatus.NOT_FOUND, exc.message, exc)
+                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, exc.message, exc)
                 is UserNotFoundException ->
-                    throw ResponseStatusException(HttpStatus.NOT_FOUND, exc.message, exc)
+                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, exc.message, exc)
                 else ->
                     throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
             }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/domain/UserAccessUpload.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/domain/UserAccessUpload.kt
@@ -1,0 +1,11 @@
+package com.apexdevs.backend.web.controller.entity.domain
+
+import com.apexdevs.backend.persistence.database.entity.DomainAccess
+import org.bson.types.ObjectId
+
+/**
+ * Object to allow the front-end to set the access level of a user in a domain.
+ * @param userId The id of the user who will receive access.
+ * @param access The access level the user gets.
+ */
+class UserAccessUpload(val userId: ObjectId, val access: DomainAccess)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/domain/UserWithAccessResponse.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/entity/domain/UserWithAccessResponse.kt
@@ -1,0 +1,19 @@
+package com.apexdevs.backend.web.controller.entity.domain
+
+import com.apexdevs.backend.persistence.database.entity.DomainAccess
+
+/**
+ * Class to send users with their access level to a domain to the front-end.
+ * @param id unique identifier of the UserDomainAccess object.
+ * @param userId The id of the user who has access.
+ * @param userDisplayName The display name of the user.
+ * @param domainId The id of the domain to which the user has access.
+ * @param accessRight The DomainAccess level the user has to the domain.
+ */
+data class UserWithAccessResponse(
+    val id: String,
+    val userId: String,
+    val userDisplayName: String,
+    val domainId: String,
+    val accessRight: DomainAccess
+)

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/DomainController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/DomainController.kt
@@ -18,7 +18,6 @@ import com.apexdevs.backend.persistence.filesystem.StorageService
 import com.apexdevs.backend.web.controller.entity.domain.DomainDetails
 import com.apexdevs.backend.web.controller.entity.domain.DomainRequest
 import com.apexdevs.backend.web.controller.entity.domain.DomainUploadRequest
-import com.apexdevs.backend.web.controller.entity.domain.UserAccessUpload
 import org.bson.types.ObjectId
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
@@ -28,8 +27,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -153,88 +150,6 @@ class DomainController(val storageService: StorageService, val domainOperation: 
             log.info("Domain: ${domain.name} with id: ${domain.id} was updated by ${u.email}")
         } catch (exc: Exception) {
             throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
-        }
-    }
-
-    /**
-     * Set the access a user has to a domain.
-     * @param user authenticated user principal, automatically retrieved from session
-     * @param id The domain to which the access is set
-     * @param userAccess The information to set the access (the user id and access level)
-     */
-    @ResponseStatus(HttpStatus.OK)
-    @PostMapping("/{id}/access")
-    fun setUserAccess(
-        @AuthenticationPrincipal user: User,
-        @PathVariable id: ObjectId,
-        @RequestBody userAccess: UserAccessUpload
-    ) {
-        try {
-            // check if the user is the owner of the domain
-            val authUser = userOperation.getByEmail(user.username)
-            val domain = domainOperation.getDomain(id)
-            val requestUserIsOwner = domainOperation.hasUserAccess(domain, DomainAccess.Owner, authUser.id)
-            if (!requestUserIsOwner)
-                throw AccessDeniedException("User is not the owner of the domain")
-
-            domainOperation.setUserAccess(id, userAccess.userId, userAccess.access)
-        } catch (exc: Exception) {
-            when (exc) {
-                is AccessDeniedException ->
-                    throw ResponseStatusException(HttpStatus.FORBIDDEN, exc.message, exc)
-                is UserNotFoundException ->
-                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, exc.message, exc)
-                else ->
-                    throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
-            }
-        }
-    }
-
-    /**
-     * Transfer ownership of a domain to a new user.
-     * The old owner will get ReadWrite access.
-     * @param user authenticated user principal, automatically retrieved from session.
-     * @param id the id of the domain to transfer ownership of.
-     * @param userId the user who will receive the ownership of the domain.
-     */
-    @ResponseStatus(HttpStatus.OK)
-    @PostMapping("{id}/transfer/{userId}")
-    fun transferOwnership(
-        @AuthenticationPrincipal user: User,
-        @PathVariable id: ObjectId,
-        @PathVariable userId: ObjectId
-    ) {
-        try {
-            // check if the user is the owner of the domain
-            val authUser = userOperation.getByEmail(user.username)
-            val domain = domainOperation.getDomain(id)
-            val requestUserIsOwner = domainOperation.hasUserAccess(domain, DomainAccess.Owner, authUser.id)
-            if (!requestUserIsOwner)
-                throw AccessDeniedException("User is not the owner of the domain")
-
-            // check if the new owner exists
-            val newOwner = userOperation.userRepository.findById(userId)
-            if (newOwner.isEmpty)
-                throw UserNotFoundException(this, "New owner with id: $userId not found")
-
-            // transfer ownership
-            domainOperation.setUserAccess(id, userId, DomainAccess.Owner)
-            domainOperation.setUserAccess(id, authUser.id, DomainAccess.ReadWrite)
-            log.info(
-                "Ownership of domain \"${domain.name}\" with id: ${domain.id} " +
-                    "transferred to user \"${newOwner.get().displayName}\" with id $userId"
-            )
-        } catch (exc: Exception) {
-            when (exc) {
-                is AccessDeniedException ->
-                    throw ResponseStatusException(HttpStatus.FORBIDDEN, exc.message, exc)
-                is DomainNotFoundException ->
-                    throw ResponseStatusException(HttpStatus.NOT_FOUND, exc.message, exc)
-                is UserNotFoundException ->
-                    throw ResponseStatusException(HttpStatus.NOT_FOUND, exc.message, exc)
-                else ->
-                    throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
-            }
         }
     }
 

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
@@ -5,6 +5,8 @@
 package com.apexdevs.backend.web.controller.routing
 
 import com.apexdevs.backend.persistence.UserOperation
+import com.apexdevs.backend.persistence.database.entity.DomainAccess
+import com.apexdevs.backend.persistence.database.entity.UserDomainAccess
 import com.apexdevs.backend.persistence.exception.UserNotFoundException
 import com.apexdevs.backend.web.controller.entity.user.UserInfo
 import org.bson.types.ObjectId
@@ -77,6 +79,9 @@ class UserController(val userOperation: UserOperation) {
         }
     }
 
+    /**
+     * Get all approved users.
+     */
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/")
     fun getUsers(@AuthenticationPrincipal user: User): List<UserInfo> {

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
@@ -5,8 +5,6 @@
 package com.apexdevs.backend.web.controller.routing
 
 import com.apexdevs.backend.persistence.UserOperation
-import com.apexdevs.backend.persistence.database.entity.DomainAccess
-import com.apexdevs.backend.persistence.database.entity.UserDomainAccess
 import com.apexdevs.backend.persistence.exception.UserNotFoundException
 import com.apexdevs.backend.web.controller.entity.user.UserInfo
 import org.bson.types.ObjectId

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/routing/UserController.kt
@@ -101,4 +101,23 @@ class UserController(val userOperation: UserOperation) {
             }
         }
     }
+
+    /**
+     * Find a user by their e-mail address.
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/email/{email}")
+    fun findUserByEmail(@AuthenticationPrincipal user: User, @PathVariable email: String): UserInfo {
+        try {
+            val foundUser = userOperation.getByEmail(email)
+            return UserInfo(foundUser, false)
+        } catch (exc: Exception) {
+            when (exc) {
+                is UserNotFoundException ->
+                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, "User with given e-mail address not found", exc)
+                else ->
+                    throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "", exc)
+            }
+        }
+    }
 }

--- a/front-end/src/components/Admin/PrivilegeManager.tsx
+++ b/front-end/src/components/Admin/PrivilegeManager.tsx
@@ -7,7 +7,9 @@ import { getSession } from 'next-auth/client';
 import styles from './PrivilegeManager.module.less';
 
 interface PrivilegeManagerState {
+  /** The user of the current session. */
   currentUser: UserInfo,
+  /** The users in the table. */
   users: UserInfo[],
 }
 

--- a/front-end/src/components/Domain/AccessManager/AccessManager.tsx
+++ b/front-end/src/components/Domain/AccessManager/AccessManager.tsx
@@ -191,6 +191,11 @@ class AccessManager extends React.Component<AccessManagerProps, AccessManagerSta
       .then((response) => response.json())
       .then((json: any) => {
         switch (json.outcome) {
+          case 0:
+            message.info('Domain ownership has been transferred');
+            this.setState({ transferOwnershipModalVisible: false });
+            onOwnershipTransferred(newOwner);
+            break;
           case 1:
             message.error('You are not allowed to transfer the ownership of this domain');
             this.setState({ transferOwnershipModalVisible: false });
@@ -199,10 +204,8 @@ class AccessManager extends React.Component<AccessManagerProps, AccessManagerSta
             message.error('Could not find the user to transfer ownership to');
             break;
           default:
-            message.info('Domain ownership has been transferred');
-            this.setState({ transferOwnershipModalVisible: false });
-            onOwnershipTransferred(newOwner);
-            break;
+            message.error('Failed to transfer ownership due to an unexpected error');
+            throw Error('Failed to transfer ownership due to an unexpected error');
         }
       })
       // eslint-disable-next-line no-console

--- a/front-end/src/components/Domain/AccessManager/AccessManager.tsx
+++ b/front-end/src/components/Domain/AccessManager/AccessManager.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { Button, message, Select, Table, Tooltip } from 'antd';
+import { Access, UserWithAccess } from '@models/Domain';
+
+const { Option } = Select;
+
+/**
+ * The props for the {@link AccessManager} component.
+ */
+interface AccessManagerProps {
+  /** The id of the domain who's access to manage. */
+  domainId: string,
+}
+
+/**
+ * The state of the {@link AccessManager} component.
+ */
+interface AccessManagerState {
+  usersWithAccess: UserWithAccess[],
+}
+
+class AccessManager extends React.Component<AccessManagerProps, AccessManagerState> {
+  constructor(props: Readonly<AccessManagerProps>) {
+    super(props);
+
+    this.state = {
+      usersWithAccess: [],
+    };
+  }
+
+  componentDidMount() {
+    this.getUsersWithAccess();
+  }
+
+  /**
+   * Get all users with access to the domain.
+   */
+  getUsersWithAccess = async () => {
+    const { domainId } = this.props;
+    const accessLevels = ['Read', 'ReadWrite'].join('/');
+
+    const endpoint = `${process.env.NEXT_PUBLIC_FE_URL}/api/domain/access/${domainId}/${accessLevels}`;
+    await fetch(endpoint, {
+      method: 'GET',
+    })
+      .then((response) => response.json())
+      .then((data) => this.setState({ usersWithAccess: data }));
+  };
+
+  /**
+   * Add table keys to the UserDomainAccess objects.
+   * @param userDomainAccessList The user domain access information array.
+   */
+  addKeys = (userDomainAccessList: UserWithAccess[]) => {
+    const result = [];
+    userDomainAccessList.forEach((access, index) => {
+      result.push({
+        // Add key
+        key: index.toString(),
+        // Add the access information
+        ...access,
+      });
+    });
+    return result;
+  };
+
+  /**
+   * Send the updated access level to the back-end.
+   * @param value The access level.
+   */
+  onAccessLevelChanged = (userId: string, value: Access) => {
+    const { domainId } = this.props;
+    const endpoint = `${process.env.NEXT_PUBLIC_FE_URL}/api/domain/access/${domainId}`;
+    fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userId, access: value }),
+    })
+      .then((response) => {
+        if (response.status !== 200) {
+          message.error('Failed to update the permission');
+        }
+      });
+  };
+
+  /**
+   * Revoke a user's access to the domain.
+   * @param userId The id of the user who's access is being revoked.
+   */
+  onRevoke = (userId: string) => {
+    const { domainId } = this.props;
+    const endpoint = `${process.env.NEXT_PUBLIC_FE_URL}/api/domain/access/${domainId}`;
+    fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userId, access: Access.Revoked }),
+    })
+      .then((response) => {
+        if (response.status !== 200) {
+          message.error('Failed to revoke access');
+        }
+        this.getUsersWithAccess();
+      });
+  };
+
+  /**
+   * Define the columns of the table.
+   */
+  columns = () => [
+    {
+      title: 'Name',
+      dataIndex: 'userDisplayName',
+    },
+    {
+      title: 'Role',
+      width: 250,
+      render: (userWithAccess: UserWithAccess) => {
+        const options = [];
+        let ind = 0;
+        Object.keys(Access).forEach((key) => {
+          // Do not include the revoked and owner access level as a selectable option
+          if (key !== 'Revoked' && key !== 'Owner') {
+            ind += 1;
+            options.push((
+              <Option
+                key={ind}
+                value={key}
+              >
+                {key}
+              </Option>
+            ));
+          }
+        });
+
+        return (
+          <Select
+            style={{ width: 200 }}
+            showSearch={true}
+            placeholder="Select a role"
+            defaultValue={userWithAccess.accessRight}
+            onChange={(value) => this.onAccessLevelChanged(userWithAccess.userId, value)}
+          >
+            {options}
+          </Select>
+        );
+      },
+    },
+    {
+      width: 100,
+      render: (userWithAccess: UserWithAccess) => (
+        <Tooltip
+          title="Revoke access"
+        >
+          <Button
+            type="primary"
+            onClick={() => this.onRevoke(userWithAccess.userId)}
+            danger
+          >
+            X
+          </Button>
+        </Tooltip>
+      ),
+    },
+  ];
+
+  render() {
+    const { usersWithAccess } = this.state;
+
+    return (
+      <Table
+        dataSource={this.addKeys(usersWithAccess)}
+        columns={this.columns()}
+      />
+    );
+  }
+}
+
+export default AccessManager;

--- a/front-end/src/components/Domain/AccessManager/AccessManager.tsx
+++ b/front-end/src/components/Domain/AccessManager/AccessManager.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import { Button, message, Select, Table, Tooltip } from 'antd';
+import { Button, Form, Input, message, Select, Table, Tooltip } from 'antd';
 import { Access, UserWithAccess } from '@models/Domain';
+import UserSearch from '@components/UserSearch/UserSearch';
+import { UserAddOutlined } from '@ant-design/icons';
+import UserInfo from '@models/User';
+import { ColumnsType } from 'antd/lib/table';
+import { getSession } from 'next-auth/client';
 
 const { Option } = Select;
 
@@ -16,19 +21,54 @@ interface AccessManagerProps {
  * The state of the {@link AccessManager} component.
  */
 interface AccessManagerState {
+  /** The user of the current session. */
+  currentUser: UserInfo,
+  currentUserIsOwner: boolean,
+  /** The users which have access to the domain (except: Owner, Revoked). */
   usersWithAccess: UserWithAccess[],
+  /** The currently selected access level for adding new users. */
+  addUserSelectedRole: Access,
 }
 
+/**
+ * Component for managing access to a domain.
+ */
 class AccessManager extends React.Component<AccessManagerProps, AccessManagerState> {
+  /** React RefObject to refer to the UserSearch element. */
+  userSearchRef: React.RefObject<Input>;
+
   constructor(props: Readonly<AccessManagerProps>) {
     super(props);
 
+    this.userSearchRef = React.createRef();
     this.state = {
+      currentUser: null,
+      currentUserIsOwner: false,
       usersWithAccess: [],
+      addUserSelectedRole: Access.Read,
     };
   }
 
-  componentDidMount() {
+  async componentDidMount() {
+    // Get the current user from the session
+    await getSession({}).then((user: any) => this.setState({ currentUser: user.user }));
+
+    // Check if the current user is the owner of this domain
+    const { domainId } = this.props;
+    const { currentUser } = this.state;
+    const endpoint = `${process.env.NEXT_PUBLIC_FE_URL}/api/domain/access/${domainId}/Owner`;
+    fetch(endpoint, {
+      method: 'GET',
+    })
+      .then((response) => response.json())
+      .then((data: UserWithAccess[]) => {
+        data.forEach((u: UserWithAccess) => {
+          if (u.userId === currentUser.userId) {
+            this.setState({ currentUserIsOwner: true });
+          }
+        });
+      });
+
     this.getUsersWithAccess();
   }
 
@@ -68,10 +108,10 @@ class AccessManager extends React.Component<AccessManagerProps, AccessManagerSta
    * Send the updated access level to the back-end.
    * @param value The access level.
    */
-  onAccessLevelChanged = (userId: string, value: Access) => {
+  updateAccessLevel = async (userId: string, value: Access) => {
     const { domainId } = this.props;
     const endpoint = `${process.env.NEXT_PUBLIC_FE_URL}/api/domain/access/${domainId}`;
-    fetch(endpoint, {
+    await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -108,33 +148,91 @@ class AccessManager extends React.Component<AccessManagerProps, AccessManagerSta
   };
 
   /**
+   * Callback function for when the access level select for adding users changes.
+   * @param value The new access level.
+   */
+  onAddUserRoleChange = (value: Access) => {
+    this.setState({ addUserSelectedRole: value });
+  };
+
+  /**
+   * When a user is selected to be added, send a request to add the user.
+   * @param user The user who is being added.
+   */
+  onAddUser = async (user: UserInfo) => {
+    const { addUserSelectedRole } = this.state;
+    await this.updateAccessLevel(user.userId, addUserSelectedRole);
+    this.getUsersWithAccess();
+    this.userSearchRef.current.setValue(null);
+  };
+
+  /**
+   * Validate that the user that is added to the permissions table is not the owner of the domain.
+   * @param email The email address that is filled in.
+   * @returns True if the user may be added, false if the user may not be added.
+   */
+  validateAddUser = (email: string): boolean => {
+    const { currentUser, currentUserIsOwner } = this.state;
+    // If the user is not the owner, the user may be added.
+    if (!currentUserIsOwner) { return true; }
+
+    /*
+     * The current user is the owner, the owner may not downgrade his/her own permissions this way.
+     * Check if the current user is about to downgrade his/her own permissions.
+     * If so, validation fails.
+     */
+    if (email === currentUser.email) {
+      message.warning('You cannot add yourself to the permissions list when you are the owner of the domain');
+      return false;
+    }
+    return true;
+  };
+
+  /**
+   * Generate a list of options for a Select for selecting access levels.
+   * @returns Options for a Select to select the access level.
+   */
+  accessOptions = () => {
+    const options = [];
+    let ind = 0;
+    Object.keys(Access).forEach((key) => {
+      // Do not include the revoked and owner access level as a selectable option
+      if (key !== 'Revoked' && key !== 'Owner') {
+        ind += 1;
+        options.push((
+          <Option
+            key={ind}
+            value={key}
+          >
+            {key}
+          </Option>
+        ));
+      }
+    });
+    return options;
+  };
+
+  /**
    * Define the columns of the table.
    */
-  columns = () => [
+  columns = (): ColumnsType<any> => [
     {
       title: 'Name',
       dataIndex: 'userDisplayName',
+      // Allow sorting by username
+      sorter: (a: UserWithAccess, b: UserWithAccess) => {
+        if (a.userDisplayName < b.userDisplayName) { return -1; }
+        if (a.userDisplayName > b.userDisplayName) { return 1; }
+        return 0;
+      },
+      sortDirections: ['ascend', 'descend'],
+      defaultSortOrder: 'ascend',
     },
     {
       title: 'Role',
       width: 250,
       render: (userWithAccess: UserWithAccess) => {
-        const options = [];
-        let ind = 0;
-        Object.keys(Access).forEach((key) => {
-          // Do not include the revoked and owner access level as a selectable option
-          if (key !== 'Revoked' && key !== 'Owner') {
-            ind += 1;
-            options.push((
-              <Option
-                key={ind}
-                value={key}
-              >
-                {key}
-              </Option>
-            ));
-          }
-        });
+        const options = this.accessOptions();
 
         return (
           <Select
@@ -142,7 +240,7 @@ class AccessManager extends React.Component<AccessManagerProps, AccessManagerSta
             showSearch={true}
             placeholder="Select a role"
             defaultValue={userWithAccess.accessRight}
-            onChange={(value) => this.onAccessLevelChanged(userWithAccess.userId, value)}
+            onChange={(value) => this.updateAccessLevel(userWithAccess.userId, value)}
           >
             {options}
           </Select>
@@ -171,10 +269,43 @@ class AccessManager extends React.Component<AccessManagerProps, AccessManagerSta
     const { usersWithAccess } = this.state;
 
     return (
-      <Table
-        dataSource={this.addKeys(usersWithAccess)}
-        columns={this.columns()}
-      />
+      <div>
+        {/* The form is only being used for styling */}
+        <Form>
+          <Form.Item
+            label="Add a user"
+            style={{ marginBottom: 0 }}
+          >
+            <Form.Item
+              style={{ display: 'inline-block', width: 'calc(25%)' }}
+            >
+              <Select
+                showSearch={true}
+                placeholder="Select a role"
+                defaultValue={Access.Read}
+                onChange={this.onAddUserRoleChange}
+              >
+                {this.accessOptions()}
+              </Select>
+            </Form.Item>
+            <Form.Item
+              style={{ display: 'inline-block', width: 'calc(75%)' }}
+            >
+              <UserSearch
+                placeholder="Add user by e-mail"
+                enterButton={<UserAddOutlined />}
+                onUserFound={this.onAddUser}
+                userValidation={this.validateAddUser}
+                ref={this.userSearchRef}
+              />
+            </Form.Item>
+          </Form.Item>
+        </Form>
+        <Table
+          dataSource={this.addKeys(usersWithAccess)}
+          columns={this.columns()}
+        />
+      </div>
     );
   }
 }

--- a/front-end/src/components/UserSearch/UserSearch.tsx
+++ b/front-end/src/components/UserSearch/UserSearch.tsx
@@ -1,14 +1,20 @@
-import React, { Ref } from 'react';
+import React, { CSSProperties, ReactNode, Ref } from 'react';
 import { Input, message } from 'antd';
 import UserInfo from '@models/User';
-import { SearchProps } from 'antd/lib/input';
 
 const { Search } = Input;
 
 /**
  * The props for the {@link UserSearch} component.
  */
-interface UserSearchProps extends SearchProps {
+interface UserSearchProps {
+  /** Placeholder text for the search field. */
+  placeholder?: string,
+  /**
+   * Whether to show an enter button after input, or use another React node.
+   * See Ant Design's documentation on Input.Search: https://ant.design/components/input/#Input.Search.
+   */
+  enterButton?: boolean | ReactNode,
   /** Callback function when a user is found. */
   onUserFound?: (user: UserInfo) => void,
   /**
@@ -16,12 +22,14 @@ interface UserSearchProps extends SearchProps {
    * Return false if a user may not be selected, or true if a user may be selected.
    */
   userValidation?: (email: string) => boolean,
+  /** CSS styling for the internal Search component. */
+  style?: CSSProperties,
 }
 
 /**
  * Component to search users by their e-mail address.
  */
-const UserSearch = React.forwardRef((props: Readonly<UserSearchProps>, ref: Ref<Input>) => {
+const UserSearch = React.forwardRef((props: UserSearchProps, ref: Ref<Input>) => {
   /**
    * Search the user with the given e-mail address.
    * @param mail The e-mail address to search by.
@@ -49,7 +57,7 @@ const UserSearch = React.forwardRef((props: Readonly<UserSearchProps>, ref: Ref<
       });
   };
 
-  const { placeholder, enterButton } = props;
+  const { placeholder, enterButton, style } = props;
 
   return (
     <Search
@@ -58,6 +66,7 @@ const UserSearch = React.forwardRef((props: Readonly<UserSearchProps>, ref: Ref<
       enterButton={enterButton}
       onSearch={searchUser}
       ref={ref}
+      style={style}
     />
   );
 });
@@ -68,6 +77,7 @@ UserSearch.defaultProps = {
   enterButton: false,
   onUserFound: () => {},
   userValidation: () => true,
+  style: null,
 };
 
 export default UserSearch;

--- a/front-end/src/components/UserSearch/UserSearch.tsx
+++ b/front-end/src/components/UserSearch/UserSearch.tsx
@@ -1,0 +1,73 @@
+import React, { Ref } from 'react';
+import { Input, message } from 'antd';
+import UserInfo from '@models/User';
+import { SearchProps } from 'antd/lib/input';
+
+const { Search } = Input;
+
+/**
+ * The props for the {@link UserSearch} component.
+ */
+interface UserSearchProps extends SearchProps {
+  /** Callback function when a user is found. */
+  onUserFound?: (user: UserInfo) => void,
+  /**
+   * Validate if a user may be selected.
+   * Return false if a user may not be selected, or true if a user may be selected.
+   */
+  userValidation?: (email: string) => boolean,
+}
+
+/**
+ * Component to search users by their e-mail address.
+ */
+const UserSearch = React.forwardRef((props: Readonly<UserSearchProps>, ref: Ref<Input>) => {
+  /**
+   * Search the user with the given e-mail address.
+   * @param mail The e-mail address to search by.
+   */
+  const searchUser = (mail: string) => {
+    const { userValidation } = props;
+    // If the user validation fails, don't continue.
+    if (userValidation(mail) === false) {
+      return;
+    }
+
+    const { onUserFound } = props;
+
+    const endpoint = `${process.env.NEXT_PUBLIC_FE_URL}/api/user/email/${mail}`;
+    fetch(endpoint, {
+      method: 'GET',
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.found === false) {
+          message.error('Could not find a user with the given e-mail address');
+          return;
+        }
+        onUserFound(data);
+      });
+  };
+
+  const { placeholder, enterButton } = props;
+
+  return (
+    <Search
+      type="email"
+      placeholder={placeholder}
+      enterButton={enterButton}
+      onSearch={searchUser}
+      ref={ref}
+    />
+  );
+});
+
+// Default values for UserSearchProps.
+UserSearch.defaultProps = {
+  placeholder: 'Search user by their email address',
+  enterButton: false,
+  onUserFound: () => {},
+  userValidation: () => true,
+};
+
+export default UserSearch;

--- a/front-end/src/models/Domain.tsx
+++ b/front-end/src/models/Domain.tsx
@@ -61,3 +61,30 @@ export enum Access {
   ReadWrite = 'ReadWrite',
   Revoked = 'Revoked'
 }
+
+/**
+ * An object received from the back-end when asked for all users with access to a domain.
+ * The relevant endpoint: `/api/domain/users-with-access/{id}`.
+ */
+export interface UserWithAccess {
+  /** The id of the UserDomainAccess object */
+  id: string,
+  /** The id of the user who has access. */
+  userId: string,
+  /** The display name of the user who has access. */
+  userDisplayName: string,
+  /** The id of the domain the user has access to. */
+  domainId: string,
+  /** The access level the user has to the domain. */
+  accessRight: Access,
+}
+
+/**
+ * Object to send user access to domain updates.
+ */
+export interface UserAccessUpload {
+  /** The id of the user who gains access. */
+  userId: string,
+  /** The access level the user will get to the domain. */
+  access: Access,
+}

--- a/front-end/src/models/User.tsx
+++ b/front-end/src/models/User.tsx
@@ -12,7 +12,7 @@ export default interface UserInfo {
   /** The display name of the user. */
   displayName: string,
   /** The status of the user account. */
-  status: string,
+  status: UserStatus,
   /** Whether the user is an administrator. */
   isAdmin: boolean,
 }

--- a/front-end/src/pages/api/domain/access/[...slug].tsx
+++ b/front-end/src/pages/api/domain/access/[...slug].tsx
@@ -7,7 +7,7 @@ import { getSession } from 'next-auth/client';
  * @param session The current session.
  * @param domainId The id of the domain to get users with access of it.
  * @param accessLevels The access levels the users may have.
- * @returns A response to the caller of this api andpoint.
+ * @returns A response to the caller of this api endpoint.
  */
 async function handleGET(res: any, session: any, domainId: string, accessLevels: any) {
   let result: UserWithAccess[] | number;
@@ -29,7 +29,7 @@ async function handleGET(res: any, session: any, domainId: string, accessLevels:
     })
     .then((data) => { result = data; });
 
-  // If an error occured, return the HTTP status code.
+  // If an error occurred, return the HTTP status code.
   if (typeof result === 'number') {
     return res.status(result).end();
   }

--- a/front-end/src/pages/api/domain/access/[...slug].tsx
+++ b/front-end/src/pages/api/domain/access/[...slug].tsx
@@ -1,0 +1,85 @@
+import { UserAccessUpload, UserWithAccess } from '@models/Domain';
+import { getSession } from 'next-auth/client';
+
+/**
+ * GET the users with access to the domain and their access levels.
+ * @param res The outgoing response.
+ * @param session The current session.
+ * @param domainId The id of the domain to get users with access of it.
+ * @param accessLevels The access levels the users may have.
+ * @returns A response to the caller of this api andpoint.
+ */
+async function handleGET(res: any, session: any, domainId: string, accessLevels: any) {
+  let result: UserWithAccess[] | number;
+
+  const accessRights = accessLevels.join(',');
+  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/api/domain/users-with-access/${domainId}?accessRights=${accessRights}`;
+  await fetch(endpoint, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      cookie: session.user.sessionid,
+    },
+  })
+    .then((response) => {
+      if (response.status !== 200) {
+        return response.status;
+      }
+      return response.json();
+    })
+    .then((data) => { result = data; });
+
+  // If an error occured, return the HTTP status code.
+  if (typeof result === 'number') {
+    return res.status(result).end();
+  }
+  return res.status(200).json(result);
+}
+
+/**
+ * POST the access right of a user to the back-end.
+ * @param res The outgoing response.
+ * @param session The current session.
+ * @param domainId The id of the domain to which rights are given.
+ * @param userAccess The user and access level.
+ */
+async function handlePOST(res: any, session: any, domainId: string, userAccess: UserAccessUpload) {
+  let result: number;
+
+  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/domain/${domainId}/access`;
+  await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      cookie: session.user.sessionid,
+    },
+    body: JSON.stringify(userAccess),
+  })
+    .then((response) => { result = response.status; });
+
+  return res.status(result).end();
+}
+
+/**
+ * Handle incoming requests.
+ * @param req The incoming request.
+ * @param res The outgoing response.
+ * @returns A response to the caller of this api endpoint.
+ */
+export default async function handler(req: any, res: any) {
+  const session: any = await getSession({ req });
+  const { method } = req;
+  const { slug } = req.query;
+
+  switch (method) {
+    case 'GET':
+      return handleGET(res, session, slug[0], slug.slice(1, slug.length));
+    case 'POST': {
+      const { body } = req;
+      return handlePOST(res, session, slug[0], body);
+    }
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      return res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}

--- a/front-end/src/pages/api/domain/access/[...slug].tsx
+++ b/front-end/src/pages/api/domain/access/[...slug].tsx
@@ -46,7 +46,7 @@ async function handleGET(res: any, session: any, domainId: string, accessLevels:
 async function handlePOST(res: any, session: any, domainId: string, userAccess: UserAccessUpload) {
   let result: number;
 
-  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/domain/${domainId}/access`;
+  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/api/domain/${domainId}/access`;
   await fetch(endpoint, {
     method: 'POST',
     headers: {

--- a/front-end/src/pages/api/domain/transfer/[id].tsx
+++ b/front-end/src/pages/api/domain/transfer/[id].tsx
@@ -10,7 +10,7 @@ export default async function handler(req: any, res: any) {
   const { id } = req.query;
   const { body } = req;
 
-  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/domain/${id}/transfer/${body}`;
+  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/api/domain/${id}/transfer/${body}`;
   await fetch(endpoint, {
     method: 'POST',
     headers: {

--- a/front-end/src/pages/api/domain/transfer/[id].tsx
+++ b/front-end/src/pages/api/domain/transfer/[id].tsx
@@ -1,0 +1,44 @@
+import { getSession } from 'next-auth/client';
+
+/**
+ * Handle incoming requests.
+ * @param req The incoming request.
+ * @param res The outgoing response.
+ */
+export default async function handler(req: any, res: any) {
+  const session: any = await getSession({ req });
+  const { id } = req.query;
+  const { body } = req;
+
+  const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/domain/${id}/transfer/${body}`;
+  await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      cookie: session.user.sessionid,
+    },
+  })
+    .then((response) => {
+      switch (response.status) {
+        case 200:
+          // Ownership transferred
+          res.status(200).json({ outcome: 0 });
+          break;
+        case 403:
+          // User is not allowed to transfer the domain ownership.
+          res.status(200).json({ outcome: 1 });
+          break;
+        case 404:
+          /*
+           * User to transfer ownership to was not found, or the domain was not found
+           * (but this is highly unlikely because the domain id was handled automatically).
+           */
+          res.status(200).json({ outcome: 2 });
+          break;
+        default:
+          res.status(response.status).json();
+          break;
+      }
+    })
+    .catch(() => res.status(500).end());
+}

--- a/front-end/src/pages/api/domain/transfer/[id].tsx
+++ b/front-end/src/pages/api/domain/transfer/[id].tsx
@@ -28,7 +28,7 @@ export default async function handler(req: any, res: any) {
           // User is not allowed to transfer the domain ownership.
           res.status(200).json({ outcome: 1 });
           break;
-        case 404:
+        case 400:
           /*
            * User to transfer ownership to was not found, or the domain was not found
            * (but this is highly unlikely because the domain id was handled automatically).

--- a/front-end/src/pages/api/user/email/[email].tsx
+++ b/front-end/src/pages/api/user/email/[email].tsx
@@ -1,0 +1,46 @@
+import { getSession } from 'next-auth/client';
+
+/**
+ * Handle GET requests.
+ * @param req The incoming request.
+ * @param res The outgoing response.
+ * @param session The current session.
+ */
+async function handleGET(req: any, res: any, session: any) {
+  const { email } = req.query;
+  const endpoint: string = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/user/email/${email}`;
+  await fetch(endpoint, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      cookie: session.user.sessionid,
+    },
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        const message = await response.json().then((e) => e.message);
+        throw new Error(message);
+      }
+      return response.json();
+    })
+    .then((data) => res.status(200).json(data))
+    .catch(() => res.status(200).json({ found: false }));
+}
+
+/**
+ * Handle incoming requests.
+ * @param req The incoming request.
+ * @param res The outgoing response.
+ */
+export default async function handler(req: any, res: any) {
+  const session: any = await getSession({ req });
+  const { method } = req;
+
+  switch (method) {
+    case 'GET':
+      return handleGET(req, res, session);
+    default:
+      res.setHeader('Allow', ['GET']);
+      return res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}

--- a/front-end/src/pages/domain/edit/[id].tsx
+++ b/front-end/src/pages/domain/edit/[id].tsx
@@ -8,12 +8,15 @@
 import React from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { Button, Result } from 'antd';
+import { Button, Result, Typography } from 'antd';
 import DomainEdit from '@components/Domain/DomainEdit/DomainEdit';
 import Domain, { Topic } from '@models/Domain';
 import { getSession } from 'next-auth/client';
 import { fetchTopics } from '@components/Domain/Domain';
+import AccessManager from '@components/Domain/AccessManager/AccessManager';
 import styles from './[id].module.less';
+
+const { Title } = Typography;
 
 /**
  * Props for DomainEditPage
@@ -98,11 +101,14 @@ function DomainEditPage({ domain, topics, notFound, access }: IDomainEditPagePro
             <Head>
               <title>Edit {domain.title} | APE</title>
             </Head>
+            <Title level={2}>Domain</Title>
             <DomainEdit
               domain={domain}
               topics={topics}
               router={router}
             />
+            <Title level={2}>Permissions</Title>
+            <AccessManager domainId={domain.id} />
           </div>
         )
       }


### PR DESCRIPTION
Allow the managing of user's permissions within domains. This is done on the domain edit page.

Summary
- Add AccessManager component.
- Add endpoint for changing a user's access to a domain.
- Add endpoint to get all users with certain access level to a domain.
- Add endpoint to transfer the ownership of a domain.
- Fix the 403 result on the domain edit page which previously redirected to a non-existent page.