### PR TITLE
[FIX] Less console errors when a domain has no use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Filtering domains based on their topics.
+- Less console errors when a domain has no use case.
 
 ## [1.2.0] - 2021-07-06
 

--- a/front-end/src/pages/explore/[id].tsx
+++ b/front-end/src/pages/explore/[id].tsx
@@ -232,14 +232,15 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
       .then((response) => {
         if (response.status === 500) {
           // There is no run config for this domain
-          return Promise.reject(new Error('no use case in this domain'));
+          return Promise.reject(new Error('No use case available in this domain.'));
         }
         return response.json();
       })
       .then((json) => {
         useCaseConfig = json;
       })
-      .catch((error) => console.error('Use case fetch error', error));
+      // eslint-disable-next-line no-console
+      .catch((error: Error) => console.log(error.message));
     await fetch(`${base}/useCaseConstraints`, {
       method: 'GET',
       credentials: 'include',
@@ -247,14 +248,15 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
       .then((response) => {
         if (response.status === 500) {
           // There is no run config for this domain
-          return Promise.reject(new Error('no use case constraints in this domain'));
+          return Promise.reject(new Error('No use case constraints available in this domain.'));
         }
         return response.json();
       })
       .then((json) => {
         useCaseConstraints = json;
       })
-      .catch((error) => console.error('Use case constraints fetch error', error));
+      // eslint-disable-next-line no-console
+      .catch((error: Error) => console.log(error.message));
 
     return {
       dataOntology,


### PR DESCRIPTION
Previously, up to four error messages were shown in the console when no use case is available for a domain. This reduces the errors to a maximum of two. The other two error messages are now (more descriptive) console log messages instead.

Summary:
- Less console errors when a domain has no use case.