### PR TITLE
[FEATURE] APE 1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Column to public domains list which shows the owner of the domain.
 - Official domains are shown with an "official" topic.
 
-## Changed
+### Changed
 
 - Update APE dependency to 1.1.8.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Column to public domains list which shows the owner of the domain.
 - Official domains are shown with an "official" topic.
 
+## Changed
+
+- Update APE dependency to 1.1.8.
+
 ### Fixed
 
 - Filtering domains based on their topics.

--- a/back-end/pom.xml
+++ b/back-end/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>io.github.sanctuuary</groupId>
 			<artifactId>APE</artifactId>
-			<version>1.1.7</version>
+			<version>1.1.8</version>
 			<exclusions>
 				<exclusion>
 					<groupId>ch.qos.logback</groupId>

--- a/back-end/src/main/kotlin/com/apexdevs/backend/ape/ApeRequest.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/ape/ApeRequest.kt
@@ -17,9 +17,9 @@ import com.apexdevs.backend.persistence.exception.RunParametersExceedLimitsExcep
 import com.apexdevs.backend.persistence.exception.SynthesisFlagException
 import guru.nidi.graphviz.attribute.Rank
 import nl.uu.cs.ape.sat.APE
-import nl.uu.cs.ape.sat.core.implSAT.SATsolutionsList
 import nl.uu.cs.ape.sat.core.solutionStructure.CWLCreator
 import nl.uu.cs.ape.sat.core.solutionStructure.ModuleNode
+import nl.uu.cs.ape.sat.core.solutionStructure.SolutionsList
 import nl.uu.cs.ape.sat.core.solutionStructure.TypeNode
 import nl.uu.cs.ape.sat.models.enums.SynthesisFlag
 import nl.uu.cs.ape.sat.models.logic.constructs.TaxonomyPredicate
@@ -34,7 +34,7 @@ import javax.imageio.ImageIO
  * @param ape APE instantiated with the correct CoreConfig
  */
 class ApeRequest(val domain: Domain, private val rootLocation: Path, val ape: APE, val runParametersOperation: RunParametersOperation) {
-    private lateinit var solutions: SATsolutionsList
+    private lateinit var solutions: SolutionsList
     /**
      * Takes a RunConfig object and adds two local paths and converts it to a JSON object to run the synthesis
      * @param runConfig The config provided that is used by APE to run it's synthesis

--- a/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/ape/ApeRequestTest.kt
@@ -21,9 +21,9 @@ import io.mockk.mockk
 import nl.uu.cs.ape.sat.APE
 import nl.uu.cs.ape.sat.constraints.ConstraintTemplate
 import nl.uu.cs.ape.sat.constraints.ConstraintTemplateParameter
-import nl.uu.cs.ape.sat.core.implSAT.SATsolutionsList
 import nl.uu.cs.ape.sat.core.solutionStructure.ModuleNode
 import nl.uu.cs.ape.sat.core.solutionStructure.SolutionWorkflow
+import nl.uu.cs.ape.sat.core.solutionStructure.SolutionsList
 import nl.uu.cs.ape.sat.core.solutionStructure.TypeNode
 import nl.uu.cs.ape.sat.models.AllModules
 import nl.uu.cs.ape.sat.models.AllTypes
@@ -59,7 +59,7 @@ internal class ApeRequestTest {
 
     @Test
     fun getWorkflows() {
-        val mockSolutionList = mockk<SATsolutionsList>()
+        val mockSolutionList = mockk<SolutionsList>()
         val mockSolutionWorkflow = mockk<SolutionWorkflow>()
         val mockTypeNode = mockk<TypeNode>()
         val mockModuleNode = mockk<ModuleNode>()
@@ -98,7 +98,7 @@ internal class ApeRequestTest {
 
     @Test
     fun `error when solutions not found`() {
-        val mockSolutionList = mockk<SATsolutionsList>()
+        val mockSolutionList = mockk<SolutionsList>()
         val mockSolutionWorkflow = mockk<SolutionWorkflow>()
         val mockConfig = mockk<RunConfig>()
         val mockJSON = mockk<JSONObject>()

--- a/front-end/src/components/WorkflowInput/WorkflowInput.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.tsx
@@ -106,7 +106,7 @@ interface WorkflowInputState {
 /**
  * This component connects the {@link InOutBox}, {@link ConstraintBox},
  * and {@link WorkflowRun} components.
- * Together, they allow for configuring APE and geting the generated workflows from APE.
+ * Together, they allow for configuring APE and getting the generated workflows from APE.
  */
 class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputState> {
   formRef = React.createRef<FormInstance>();

--- a/front-end/src/pages/explore/[id].tsx
+++ b/front-end/src/pages/explore/[id].tsx
@@ -131,7 +131,7 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
     super(props);
 
     /*
-     * Eventhough we initiate the values of the data in initAPE, we have
+     * Even though we initiate the values of the data in initAPE, we have
      * to assign a value, because to order of calls is:
      * constructor -> render -> componentDidMount -> render
      * And otherwise the first render will fail
@@ -174,7 +174,6 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
       method: 'GET',
       credentials: 'include',
     })
-      .then(() => console.log('APE instantiated'))
       .catch((error) => console.error('APE instantiate error', error));
 
     // The base URL for the data, tool, and constraint fetch
@@ -197,8 +196,11 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
       credentials: 'include',
     })
       .then((response) => response.json())
-      .then((json) => {
-        dataOntology = json;
+      .then((json: Ontology) => {
+        // APE label is part of a future feature. Ignore it for now.
+        const noApeLabel = json;
+        noApeLabel.roots = noApeLabel.roots.filter((r) => r.id !== 'APE_label');
+        dataOntology = noApeLabel;
       })
       .catch((error) => console.error('Data fetch error', error));
 


### PR DESCRIPTION
Update the APE dependency from 1.1.7 to 1.1.8.
This includes disabling the "APE Label" feature in the new APE version. It will be re-added later when this feature is ready for APE Web.

Summary:
- Update APE dependency to 1.1.8.