### PR TITLE
[HOTFIX] Broken explore page access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Public domains can be explored again without logging in.
+- Add missing "no access" result page when trying to explore a domain a user does not have access to.
 
 ## [1.3.1] - 2021-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Public domains can be explored again without logging in.
+
 ## [1.3.1] - 2021-08-09
 
 ### Added

--- a/front-end/src/pages/explore/[id].tsx
+++ b/front-end/src/pages/explore/[id].tsx
@@ -371,13 +371,17 @@ export async function getServerSideProps({ req, query }) {
   // Get the current domain
   const domainEndpoint = `${process.env.NEXT_PUBLIC_BASE_URL_NODE}/domain/${query.id}/`;
   let domain: any = {};
-  await fetch(domainEndpoint, {
+  const init: RequestInit = {
     method: 'GET',
     credentials: 'include',
-    headers: {
+  };
+  // Only include cookie if a user is logged in
+  if (session !== null) {
+    init.headers = {
       cookie: session.user.sessionid,
-    },
-  })
+    };
+  }
+  await fetch(domainEndpoint, init)
     .then((response) => {
       if (response.status !== 200) {
         throw new Error(`Failed to GET domain: ${response.statusText}`);


### PR DESCRIPTION
Fixes critical issues in APE Web 1.3.1.

Summary:
- Fix public domains not being explorable when not logged in.
- Fix explore page not having a "no access" result.