### PR TITLE
[FEATURE] Add the domain name on the domain explore page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The domain name is now shown on the domain explore page.
+
 ## [1.3.2] - 2021-08-09
 
 ### Fixed

--- a/front-end/src/components/WorkflowInput/WorkflowInput.module.less
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.module.less
@@ -11,9 +11,16 @@
   display: block;
   left: 0px;
   background-color: @upload-bar-color;
-  margin-left: calc(-50vw + 50%);
   align-items: center;
   justify-content: center;
+}
+
+.DomainHeader {
+  padding-bottom: 5px;
+  margin-bottom: 5px !important;
+  text-align: center;
+  background-color: @explore-page-title-background;
+  font-weight: normal !important;
 }
 
 .Icon {

--- a/front-end/src/components/WorkflowInput/WorkflowInput.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { Button, Divider, message, Modal, Upload } from 'antd';
+import { Button, Divider, message, Modal, Typography, Upload } from 'antd';
 import { UploadOutlined, DownloadOutlined } from '@ant-design/icons';
 import WorkflowRun from '@components/WorkflowInput/WorkflowRun';
 import InOutBox from '@components/Explore/InOutBox/InOutBox';
@@ -29,11 +29,17 @@ import ConstraintSketcher, { Sketch } from '@components/WorkflowInput/Constraint
 import { translateSketch } from '@components/WorkflowInput/ConstraintSketcher/SketchTranslation';
 import { Config } from '@models/Configuration/Config';
 import { FormInstance } from 'antd/lib/form';
+import Domain from '@models/Domain';
 import { clamp } from '@helpers/Math';
 import styles from './WorkflowInput.module.less';
 
+const { Title } = Typography;
+
 /** The props for the {@link WorkflowInput} component */
 interface WorkflowInputProps {
+  /** The domain that is being explored. */
+  domain: Domain,
+
   /**
    * The onRun function that passes the parameters through to
    * the home page.
@@ -55,9 +61,6 @@ interface WorkflowInputProps {
 
   /** Use case constraints of the domain */
   useCaseConstraints: ConstraintsConfig;
-
-  /** The domain ID */
-  domain: string;
 
   /** The run parameters limits */
   runParametersLimits: RunOptions;
@@ -894,6 +897,7 @@ class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputSta
     } = this.state;
 
     const {
+      domain,
       dataOntology,
       toolOntology,
       constraintOptions,
@@ -906,6 +910,7 @@ class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputSta
 
     return (
       <div className="WorkflowInput">
+        <Title level={2} className={styles.DomainHeader}>{domain.title}</Title>
         <div className={styles.ImportExport}>
           <Button
             type="default"

--- a/front-end/src/pages/explore/[id].tsx
+++ b/front-end/src/pages/explore/[id].tsx
@@ -364,7 +364,7 @@ class ExplorePage extends React.Component<IExplorePageProps, IExplorePageState> 
             constraintOptions={constraintOptions}
             useCaseConfig={useCaseConfig}
             useCaseConstraints={useCaseConstraints}
-            domain={domain.id}
+            domain={domain}
             runParametersLimits={runParametersLimits}
           />
         </Layout>

--- a/front-end/src/styles/_colors.less
+++ b/front-end/src/styles/_colors.less
@@ -20,6 +20,7 @@
 @color-3: #F7A194;
 @background-color: #dddddd;
 @header-color: #6b6b6b;
+@explore-page-title-background: #a5a5a5;
 @upload-bar-color: #b6b6b6;
 @color-6: #ababab;
 @color-7: #429D76;


### PR DESCRIPTION
Previously, on the domain explore page, the domain name was only shown in the webpage title. The domain name is now also shown on the explore page itself.

Summary:
- Add the domain name on the domain explore page.