### PR TITLE
[FEATURE] Highlight additional workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The domain name is now shown on the domain explore page.
+- Notification explaining how to navigate the workflows on the explore page appears when the user selects more workflows for the first time.
 
 ## [1.3.2] - 2021-08-09
 


### PR DESCRIPTION
Previously, it was not always clear that more workflows appear on the right (often outside of the screen) when a user selects more workflows to view on the explore page. This adds a notification which appears when the user selects an additional workflow. The notification explains there are more workflows to the right, and explains how to navigate to them.

Summary:
- Add notification explaining how to navigate workflows on the explore page.