### PR TITLE
[FEATURE] Improve additional workflows notification

### DIFF
--- a/front-end/src/components/Explore/Explore.tsx
+++ b/front-end/src/components/Explore/Explore.tsx
@@ -125,7 +125,7 @@ class Explore extends React.Component<ExploreProps, ExploreState> {
      */
     if (scrollNotificationShown === 0) {
       this.setState({ scrollNotificationShown: 1 });
-    } else if (scrollNotificationShown === 1) {
+    } else if (scrollNotificationShown === 1 && selected.length > 2) {
       /*
        * Show the scroll notification on the second selection
        * (this is the fist selection made by the user).

--- a/front-end/src/components/Explore/Explore.tsx
+++ b/front-end/src/components/Explore/Explore.tsx
@@ -137,8 +137,7 @@ class Explore extends React.Component<ExploreProps, ExploreState> {
         description: (
           <p>
             More workflows are shown to the right.
-            Use the <strong>scrollbar below</strong>,
-            or <strong>shift+scroll wheel</strong> below the workflows to navigate to them.
+            Use the <strong>scrollbar below</strong> to navigate to them.
           </p>
         ),
         placement: 'bottomRight',


### PR DESCRIPTION
Applying some feedback and fixing an issue.

Summary:
- The navigate workflows notification now only appears the first time more than two workflows are selected (instead of the first time any change in the selected workflows happens).
- Simplify the navigate workflows notification message (remove the mouse wheel information).