### PR TITLE
[FIX] Workflow run error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OntologyTreeSelect's dropdown is now wider to fit all items.
 - OntologyTreeSelect now better handles items with the same name.
 - Several errors surrounding the constraint sketcher.
+- APE synthesis flag messages sometimes being empty.
 
 ## [1.3.2] - 2021-08-09
 

--- a/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/SynthesisFlagException.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/persistence/exception/SynthesisFlagException.kt
@@ -4,8 +4,8 @@ import nl.uu.cs.ape.sat.models.enums.SynthesisFlag
 
 class SynthesisFlagException(val from: Any, val flag: SynthesisFlag) : RuntimeException(flag.message) {
     /**
-     * Overrides some of APE's SynthesisFlag messages with user friendly messages which can be shown on the front-end.
-     * @return A user friendly message describing the reason the synthesis was interrupted.
+     * Overrides some of APE's SynthesisFlag messages with user-friendly messages which can be shown on the front-end.
+     * @return A user-friendly message describing the reason the synthesis was interrupted.
      */
     fun getFriendlyMessage(): String {
         return when (flag) {

--- a/back-end/src/main/resources/application.properties
+++ b/back-end/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.servlet.multipart.max-request-size=10240KB
 spring.servlet.multipart.location=domains
 server.error.whitelabel.enabled=true
 server.error.include-stacktrace=always
+server.error.include-message=always
 server.servlet.session.timeout=3600
 logging.config=classpath:logback-spring.xml
 # Database credentials

--- a/front-end/src/components/WorkflowInput/WorkflowInput.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowInput.tsx
@@ -579,7 +579,11 @@ class WorkflowInput extends React.Component<WorkflowInputProps, WorkflowInputSta
       .catch((error) => {
         // Await error parsing
         error.then((data: any) => {
-          message.error(data.message, 5);
+          if (data.message.includes('unknown')) {
+            message.error(data.message, 5);
+          } else {
+            message.warn(data.message, 5);
+          }
         });
       });
   };


### PR DESCRIPTION
When deployed on some systems, the back-end would not sent the synthesis flag messages from APE to the front-end. This resulted in empty messages being shown to the user on a failed workflow run.

Summary:
- Fix APE synthesis flag messages sometimes being empty. 