### PR TITLE
[FEATURE] APE 1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notification explaining how to navigate the workflows on the explore page appears when the user selects more workflows for the first time.
 - Add .cff and .bib citation files.
 
+### Changed
+
+- Update APE dependency to 1.1.9.
+- Change "CWL (beta)" download to "Abstract CWL" download.
+
 ### Fixed
 
 - OntologyTreeSelect's dropdown is now wider to fit all items.

--- a/back-end/pom.xml
+++ b/back-end/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>io.github.sanctuuary</groupId>
 			<artifactId>APE</artifactId>
-			<version>1.1.8</version>
+			<version>1.1.9</version>
 			<exclusions>
 				<exclusion>
 					<groupId>ch.qos.logback</groupId>

--- a/back-end/src/main/kotlin/com/apexdevs/backend/ape/ApeRequest.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/ape/ApeRequest.kt
@@ -17,7 +17,7 @@ import com.apexdevs.backend.persistence.exception.RunParametersExceedLimitsExcep
 import com.apexdevs.backend.persistence.exception.SynthesisFlagException
 import guru.nidi.graphviz.attribute.Rank
 import nl.uu.cs.ape.sat.APE
-import nl.uu.cs.ape.sat.core.solutionStructure.CWLCreator
+import nl.uu.cs.ape.sat.core.solutionStructure.AbstractCWLCreator
 import nl.uu.cs.ape.sat.core.solutionStructure.ModuleNode
 import nl.uu.cs.ape.sat.core.solutionStructure.SolutionsList
 import nl.uu.cs.ape.sat.core.solutionStructure.TypeNode
@@ -166,15 +166,16 @@ class ApeRequest(val domain: Domain, private val rootLocation: Path, val ape: AP
     }
 
     /**
+     * Generate the abstract CWL representation of a certain solution.
      * @param index id of wanted solution
      * @return cwl content as a ByteArray
      */
-    fun generateCwl(index: Int): ByteArray {
+    fun generateAbstractCwl(index: Int): ByteArray {
         if (::solutions.isInitialized)
             if (index > solutions.numberOfSolutions)
                 throw Exception("This solution does not exist.")
             else
-                return CWLCreator(solutions[index], ape.config).cwl.toByteArray()
+                return AbstractCWLCreator(solutions[index]).generate().toByteArray()
         else
             throw Exception("No solutions could be found with the given input and output")
     }

--- a/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowController.kt
+++ b/back-end/src/main/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowController.kt
@@ -214,10 +214,10 @@ class ApiWorkflowController(
      * @return a CWL script of requested solution
      */
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/cwl/{solutionId}")
-    fun getSolutionCwl(session: HttpSession, @PathVariable solutionId: List<Int>): ResponseEntity<Resource> {
+    @GetMapping("/cwl/abstract/{solutionId}")
+    fun getSolutionAbstractCwl(session: HttpSession, @PathVariable solutionId: List<Int>): ResponseEntity<Resource> {
         try {
-            val solutionConverter: (Int) -> ByteArray = { id -> apeRequestFactory.getApeRequest(session.id).generateCwl(id) }
+            val solutionConverter: (Int) -> ByteArray = { id -> apeRequestFactory.getApeRequest(session.id).generateAbstractCwl(id) }
             return storageService.indexToResponseEntity(solutionId, solutionConverter, "cwl", "workflow_CWL")
         } catch (exc: Exception) {
             throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowControllerTest.kt
+++ b/back-end/src/test/kotlin/com/apexdevs/backend/web/controller/api/ApiWorkflowControllerTest.kt
@@ -154,11 +154,11 @@ class ApiWorkflowControllerTest() {
     fun getCWL() {
         val testValue = "Test"
         val response = mockk<ResponseEntity<Resource>>()
-        every { apeRequest.generateCwl(any()) } returns testValue.toByteArray()
+        every { apeRequest.generateAbstractCwl(any()) } returns testValue.toByteArray()
         every { storageService.indexToResponseEntity(any(), any(), any(), any()) } returns response
         every { storageService.resourcesToZip(any(), any()) } returns response
 
-        assertEquals(response, apiWorkflowController.getSolutionCwl(session, listOf(1, 2)))
+        assertEquals(response, apiWorkflowController.getSolutionAbstractCwl(session, listOf(1, 2)))
     }
 
     @Test

--- a/front-end/src/components/Explore/Sidebar/Sidebar.tsx
+++ b/front-end/src/components/Explore/Sidebar/Sidebar.tsx
@@ -80,7 +80,7 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
   downloadMenu = () => (
     <Menu onClick={this.downloadSelectedWorkflows}>
       <Menu.Item key="bash" icon={<DownloadOutlined />}>Bash</Menu.Item>
-      <Menu.Item key="cwl" icon={<DownloadOutlined />}>CWL (beta)</Menu.Item>
+      <Menu.Item key="cwl" icon={<DownloadOutlined />}>Abstract CWL</Menu.Item>
       <Menu.Item key="png" icon={<DownloadOutlined />}>PNG</Menu.Item>
     </Menu>
   );
@@ -104,7 +104,12 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
     }
 
     const dataString = checkedList.join(',');
-    const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL}/api/workflow/${type}/${dataString}`;
+    let endpoint: string = null;
+    if (type === 'cwl') {
+      endpoint = `${process.env.NEXT_PUBLIC_BASE_URL}/api/workflow/cwl/abstract/${dataString}`;
+    } else {
+      endpoint = `${process.env.NEXT_PUBLIC_BASE_URL}/api/workflow/${type}/${dataString}`;
+    }
 
     // Download the file
     await fetch(endpoint, {

--- a/front-end/src/components/Explore/WorkflowVisualizer/WorkflowVisualizer.tsx
+++ b/front-end/src/components/Explore/WorkflowVisualizer/WorkflowVisualizer.tsx
@@ -191,7 +191,7 @@ class WorkflowVisualizer extends React.Component<WorkflowVisualizerProps, Workfl
         extension = 'sh';
         break;
       case 'cwl':
-        endpoint = `${process.env.NEXT_PUBLIC_BASE_URL}/api/workflow/cwl/${data.id}`;
+        endpoint = `${process.env.NEXT_PUBLIC_BASE_URL}/api/workflow/cwl/abstract/${data.id}`;
         extension = 'cwl';
         break;
       case 'png':
@@ -230,7 +230,7 @@ class WorkflowVisualizer extends React.Component<WorkflowVisualizerProps, Workfl
   downloadMenu = () => (
     <Menu onClick={this.handleDownloadClick}>
       <Menu.Item key="bash" icon={<DownloadOutlined />}>Bash</Menu.Item>
-      <Menu.Item key="cwl" icon={<DownloadOutlined />}>CWL (beta)</Menu.Item>
+      <Menu.Item key="cwl" icon={<DownloadOutlined />}>Abstract CWL</Menu.Item>
       <Menu.Item key="png" icon={<DownloadOutlined />}>PNG</Menu.Item>
     </Menu>
   );


### PR DESCRIPTION
Update APE dependency to APE 1.1.9 to allow for CWL export.

Summary:
- Update to APE 1.1.9.
- Change "CWL (beta)" download option to "Abstract CWL".