### PR TITLE
[FIX] Make size limit for file uploads configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update APE dependency to 1.1.9.
 - Change "CWL (beta)" download to "Abstract CWL" download.
+- Make it possible to configure the size limit of file uploads in the .env files (default: 10MB).
 
 ### Fixed
 

--- a/front-end/.env
+++ b/front-end/.env
@@ -18,3 +18,6 @@ APPLICATION_SECRET=a_long_secret_with_at_least_32_chars
 
 # Next auth api url
 NEXTAUTH_URL=https://example.com/api/auth
+
+# File size upload limit (in MB)
+NEXT_PUBLIC_FILE_SIZE_LIMIT=10

--- a/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
+++ b/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
@@ -148,12 +148,15 @@ class DomainCreate extends React.Component<{router, session}, IState> {
             router.push('/');
             return Promise.resolve(message.success('Domain successfully created'));
           }
-          return Promise.reject(message.error('Something went wrong'));
+          if (response.status === 413) {
+            const limit = process.env.NEXT_PUBLIC_FILE_SIZE_LIMIT;
+            return Promise.reject(new Error(`Some files were too large. The maximum file size is ${limit}MB.`));
+          }
+          return Promise.reject(new Error('Error while trying to create domain'));
         })
         // Catch and print any errors
-        .catch((error) => {
-          message.error('Error while trying to create domain');
-          console.error(error);
+        .catch((error: Error) => {
+          message.error(error.message, 5);
         });
     });
   };

--- a/front-end/src/pages/api/domain/upload.tsx
+++ b/front-end/src/pages/api/domain/upload.tsx
@@ -10,6 +10,14 @@ import FormData from 'formdata-node';
 import Blob from 'fetch-blob';
 import { FileContent } from '@helpers/Files';
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: `${process.env.NEXT_PUBLIC_FILE_SIZE_LIMIT}mb`,
+    },
+  },
+};
+
 /**
  * Proxy endpoint for uploading domains
  */


### PR DESCRIPTION
The file size limit was too low. The size limit is now configurable via the .env file of the front-end.

Summary:
- Make file size limit for uploads configurable.
- Set default file size limit to 10MB.