### PR TITLE
[FIX] Run parameters required check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update APE dependency to 1.1.9.
 - Change "CWL (beta)" download to "Abstract CWL" download.
 - Make it possible to configure the size limit of file uploads in the .env files (default: 10MB).
+- Run parameter field "Max duration (s)" is now "Max duration (seconds)".
 
 ### Fixed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - APE synthesis flag messages sometimes being empty.
 - OntologyTreeSelect search function.
 - First tree node in OntologyTreeSelect not expanding by default.
+- Run parameter fields are now required.
 
 ## [1.3.2] - 2021-08-09
 

--- a/front-end/src/components/WorkflowInput/WorkflowRun.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowRun.tsx
@@ -105,8 +105,14 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
             initialValues={options}
             ref={formRef}
             name="control-ref"
+            requiredMark={false}
           >
-            <Form.Item name="minLength" label="Min steps" className={Styles.Label}>
+            <Form.Item
+              name="minLength"
+              label="Min steps"
+              className={Styles.Label}
+              rules={[{ required: true, message: 'The minimum length is required' }]}
+            >
               <InputNumber
                 id="minLength"
                 min={0}
@@ -115,7 +121,12 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
               />
             </Form.Item>
 
-            <Form.Item name="maxLength" label="Max steps" className={Styles.Label}>
+            <Form.Item
+              name="maxLength"
+              label="Max steps"
+              className={Styles.Label}
+              rules={[{ required: true, message: 'The maximum length is required' }]}
+            >
               <InputNumber
                 id="maxLength"
                 min={0}
@@ -124,7 +135,12 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
               />
             </Form.Item>
 
-            <Form.Item name="maxDuration" label="Max duration (s)" className={Styles.Label}>
+            <Form.Item
+              name="maxDuration"
+              label="Max duration (s)"
+              className={Styles.Label}
+              rules={[{ required: true, message: 'The maximum duration is required' }]}
+            >
               <InputNumber
                 id="maxDuration"
                 min={0}
@@ -133,7 +149,13 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
               />
             </Form.Item>
 
-            <Form.Item name="solutions" label="Number of solutions" className={Styles.Label} labelAlign="right">
+            <Form.Item
+              name="solutions"
+              label="Number of solutions"
+              className={Styles.Label}
+              labelAlign="right"
+              rules={[{ required: true, message: 'The number of solutions is required' }]}
+            >
               <InputNumber
                 id="solutions"
                 min={0}

--- a/front-end/src/components/WorkflowInput/WorkflowRun.tsx
+++ b/front-end/src/components/WorkflowInput/WorkflowRun.tsx
@@ -137,7 +137,7 @@ class WorkflowRun extends React.Component<WorkflowRunProps, WorkflowRunState> {
 
             <Form.Item
               name="maxDuration"
-              label="Max duration (s)"
+              label="Max duration (seconds)"
               className={Styles.Label}
               rules={[{ required: true, message: 'The maximum duration is required' }]}
             >


### PR DESCRIPTION
It was possible to not fill in the run parameters. When this happens, it would use the previous values. The run parameter fields are now required fields and it will not let users run APE without filling them in.

Summary:
- Run parameter fields are now required.
- Run parameter field "Max duration (s)" is now "Max duration (seconds)".