### PR TITLE
[FEATURE] Improved domain tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change "CWL (beta)" download to "Abstract CWL" download.
 - Make it possible to configure the size limit of file uploads in the .env files (default: 10MB).
 - Improved tooltips on the domain creation page.
+- Improved tooltips on the domain edit page.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update APE dependency to 1.1.9.
 - Change "CWL (beta)" download to "Abstract CWL" download.
 - Make it possible to configure the size limit of file uploads in the .env files (default: 10MB).
+- Improved tooltips on the domain creation page.
 
 ### Fixed
 

--- a/front-end/src/components/Domain/Domain.tsx
+++ b/front-end/src/components/Domain/Domain.tsx
@@ -11,6 +11,8 @@
  *
  * @packageDocumentation
  */
+import React, { ReactNode } from 'react';
+import { Modal } from 'antd';
 import { Topic } from '@models/Domain';
 
 /**
@@ -31,4 +33,79 @@ export async function fetchTopics(user: any, serverside: boolean = false): Promi
     headers: { cookie: user.sessionid },
   });
   return response.json();
+}
+
+/**
+ * Create modal for advanced tooltip information.
+ * @param title The title of the modal.
+ * @param visible Whether the modal is visible / open.
+ * @param cancel The function to call when the "onCancel" event is called.
+ * @param content The content of the modal.
+ * @returns A modal that acts as an advanced tooltip.
+ */
+export function tooltipModal(
+  title: string,
+  visible: boolean,
+  cancel: () => void,
+  content: ReactNode,
+) {
+  return (
+    <Modal
+      title={title}
+      visible={visible}
+      footer={false}
+      onCancel={cancel}
+      width={1000}
+    >
+      {content}
+    </Modal>
+  );
+}
+
+/**
+ * The tooltip modal for ontology files.
+ * @param visible Whether this modal is currently visible / open.
+ * @param cancel The function to call when the "onCancel" event is called.
+ * @returns The tooltip modal for ontology files.
+ */
+export function ontologyModal(visible: boolean, cancel: () => void) {
+  return tooltipModal('Ontology file', visible, cancel, (
+    <p>Information about ontology files.</p>
+  ));
+}
+
+/**
+ * The tooltip modal for tool annotations files.
+ * @param visible Whether this modal is currently visible / open.
+ * @param cancel The function to call when the "onCancel" event is called.
+ * @returns The tooltip modal for tool annotations files.
+ */
+export function toolAnnotationsModal(visible: boolean, cancel: () => void) {
+  return tooltipModal('Tool annotations file', visible, cancel, (
+    <p>Information about tool annotations.</p>
+  ));
+}
+
+/**
+ * The tooltip modal for run config files.
+ * @param visible Whether this modal is currently visible / open.
+ * @param cancel The function to call when the "onCancel" event is called.
+ * @returns The tooltip modal for run config files.
+ */
+export function runConfigModal(visible: boolean, cancel: () => void) {
+  return tooltipModal('Run configuration file', visible, cancel, (
+    <p>Information about the run configuration.</p>
+  ));
+}
+
+/**
+ * The tooltip modal for constraints files.
+ * @param visible Whether this modal is currently visible / open.
+ * @param cancel The function to call when the "onCancel" event is called.
+ * @returns The tooltip modal for constraints files.
+ */
+export function constraintsModal(visible: boolean, cancel: () => void) {
+  return tooltipModal('Constraints file', visible, cancel, (
+    <p>Information about the constraints file.</p>
+  ));
 }

--- a/front-end/src/components/Domain/Domain.tsx
+++ b/front-end/src/components/Domain/Domain.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /* eslint-disable import/prefer-default-export */
 /*
  * This program has been developed by students from the bachelor Computer Science at
@@ -7,13 +8,15 @@
  */
 
 /**
- * Shared behaviour for the Domain components.
+ * Shared behavior for the Domain components.
  *
  * @packageDocumentation
  */
 import React, { ReactNode } from 'react';
-import { Modal } from 'antd';
+import { Modal, Typography } from 'antd';
 import { Topic } from '@models/Domain';
+
+const { Paragraph } = Typography;
 
 /**
  * Fetch all topics from the back-end.
@@ -69,8 +72,14 @@ export function tooltipModal(
  * @returns The tooltip modal for ontology files.
  */
 export function ontologyModal(visible: boolean, cancel: () => void) {
-  return tooltipModal('Ontology file', visible, cancel, (
-    <p>Information about ontology files.</p>
+  return tooltipModal('How to create an ontology file', visible, cancel, (
+    <div>
+      <Paragraph>Ontology file should specify the<strong>&nbsp;ontology (taxonomy)&nbsp;</strong>that&nbsp;specifies the domain vocabulary. It should be provided in the<strong> OWL </strong>or<strong> RDF format.</strong>&nbsp;</Paragraph>
+      <Paragraph><em><a href="https://protege.stanford.edu/" target="_blank" rel="noreferrer noopener">Prot&eacute;g&eacute;</a>&nbsp;is the suggested ontology editor.</em></Paragraph>
+      <Paragraph>An exemplary ontology file can be downloaded&nbsp;<a href="https://raw.githubusercontent.com/sanctuuary/APE_UseCases/master/ImageMagick/imagemagick_taxonomy.owl" target="_blank" rel="noreferrer noopener">here</a>&nbsp;(the exemplary domain is defined over the&nbsp;<a href="https://ape-framework.readthedocs.io/en/latest/docs/demo/imagemagick/imagemagick.html" target="_blank" rel="noreferrer noopener">Image Magick</a> toolset).&nbsp;</Paragraph>
+      <Paragraph>&nbsp;&nbsp;</Paragraph>
+      <Paragraph><strong>For a detailed description of the ontology file we refer to the corresponding&nbsp;<a href="https://ape-framework.readthedocs.io/en/latest/docs/specifications/setup.html#id1" target="_blank" rel="noreferrer noopener">readthedocs</a> documentation.&nbsp;</strong></Paragraph>
+    </div>
   ));
 }
 
@@ -81,8 +90,13 @@ export function ontologyModal(visible: boolean, cancel: () => void) {
  * @returns The tooltip modal for tool annotations files.
  */
 export function toolAnnotationsModal(visible: boolean, cancel: () => void) {
-  return tooltipModal('Tool annotations file', visible, cancel, (
-    <p>Information about tool annotations.</p>
+  return tooltipModal('How to create a tool annotations file', visible, cancel, (
+    <div>
+      <Paragraph>Tool annotation file should specify the<strong>&nbsp;tool annotations </strong>with respect to their&nbsp;<strong>inputs&nbsp;</strong>and&nbsp;<strong>outputs</strong>.&nbsp;It should be provided in the<strong> JSON</strong><strong>&nbsp;format.</strong>&nbsp;</Paragraph>
+      <Paragraph>An exemplary tool annotation file can be downloaded&nbsp;<a href="https://raw.githubusercontent.com/sanctuuary/APE_UseCases/master/ImageMagick/tool_annotations.json" target="_blank" rel="noreferrer noopener">here</a>&nbsp;(the exemplary domain is defined over the&nbsp;<a href="https://ape-framework.readthedocs.io/en/latest/docs/demo/imagemagick/imagemagick.html" target="_blank" rel="noreferrer noopener">Image Magick</a> toolset).&nbsp;</Paragraph>
+      <Paragraph>&nbsp;&nbsp;</Paragraph>
+      <Paragraph><strong>For a detailed description of the tool annotation file we refer to the corresponding&nbsp;<a href="https://ape-framework.readthedocs.io/en/latest/docs/specifications/setup.html#tool-annotations" target="_blank" rel="noreferrer noopener">readthedocs</a> documentation.&nbsp;</strong></Paragraph>
+    </div>
   ));
 }
 
@@ -93,8 +107,13 @@ export function toolAnnotationsModal(visible: boolean, cancel: () => void) {
  * @returns The tooltip modal for run config files.
  */
 export function runConfigModal(visible: boolean, cancel: () => void) {
-  return tooltipModal('Run configuration file', visible, cancel, (
-    <p>Information about the run configuration.</p>
+  return tooltipModal('How to create a run configuration file', visible, cancel, (
+    <div>
+      <Paragraph>Run configuration file should specify the<strong> basic run configuration</strong> (timeout, expected number of solution, etc.) as well as the <strong>inputs </strong>and<strong> outputs</strong> for the demonstration synthesis run.&nbsp;</Paragraph>
+      <Paragraph>An exemplary configuration file can be downloaded&nbsp;<a href="https://raw.githubusercontent.com/sanctuuary/APE_UseCases/master/ImageMagick/Example1/config.json" target="_blank" rel="noreferrer noopener">here</a>&nbsp;(the exemplary domain is defined over the&nbsp;<a href="https://ape-framework.readthedocs.io/en/latest/docs/demo/imagemagick/imagemagick.html" target="_blank" rel="noreferrer noopener">Image Magick</a> toolset).</Paragraph>
+      <Paragraph>&nbsp;</Paragraph>
+      <Paragraph><strong>For a detailed description of the configuration file we refer to&nbsp;the corresponding <a href="https://ape-framework.readthedocs.io/en/latest/docs/specifications/setup.html#configuration-file" target="_blank" rel="noreferrer noopener">readthedocs</a> documentation.&nbsp;</strong></Paragraph>
+    </div>
   ));
 }
 
@@ -105,7 +124,12 @@ export function runConfigModal(visible: boolean, cancel: () => void) {
  * @returns The tooltip modal for constraints files.
  */
 export function constraintsModal(visible: boolean, cancel: () => void) {
-  return tooltipModal('Constraints file', visible, cancel, (
-    <p>Information about the constraints file.</p>
+  return tooltipModal('How to create a constraints file', visible, cancel, (
+    <div>
+      <Paragraph>Constraints file should specify the<strong>&nbsp;constraints </strong>used<strong>&nbsp;</strong>for the demonstration synthesis run.&nbsp;</Paragraph>
+      <Paragraph>An exemplary configuration file can be downloaded&nbsp;<a href="https://raw.githubusercontent.com/sanctuuary/APE_UseCases/master/ImageMagick/Example1/constraints.json" target="_blank" rel="noreferrer noopener">here</a>&nbsp;(the exemplary domain is defined over the&nbsp;<a href="https://ape-framework.readthedocs.io/en/latest/docs/demo/imagemagick/imagemagick.html" target="_blank" rel="noreferrer noopener">Image Magick</a> toolset).</Paragraph>
+      <Paragraph>&nbsp;</Paragraph>
+      <Paragraph><strong>For a detailed description of the constraints file we refer to&nbsp;the corresponding <a href="https://ape-framework.readthedocs.io/en/latest/docs/specifications/setup.html#constraints-file" target="_blank" rel="noreferrer noopener">readthedocs</a> documentation.&nbsp;</strong></Paragraph>
+    </div>
   ));
 }

--- a/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
+++ b/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
@@ -210,6 +210,7 @@ class DomainCreate extends React.Component<{router, session}, IState> {
                       </ul>
                     </div>
                   ),
+                  color: 'black',
                 }}
               >
                 <Select
@@ -237,7 +238,7 @@ class DomainCreate extends React.Component<{router, session}, IState> {
               <Form.Item
                 name="useCaseRunConfig"
                 label="Run configuration:"
-                tooltip={{ title: 'Configuration used for a demo run' }}
+                tooltip={{ title: 'Configuration used for a demo run', color: 'black' }}
               >
                 <Upload
                   beforeUpload={validateJSON}
@@ -255,7 +256,7 @@ class DomainCreate extends React.Component<{router, session}, IState> {
               <Form.Item
                 name="useCaseConstraints"
                 label="Constraints:"
-                tooltip={{ title: 'Constraints used for a demo run' }}
+                tooltip={{ title: 'Constraints used for a demo run', color: 'black' }}
               >
                 <Upload
                   beforeUpload={validateJSON}
@@ -277,6 +278,7 @@ class DomainCreate extends React.Component<{router, session}, IState> {
                 name="ontologyPrefix"
                 label="Ontology prefix:"
                 rules={[{ required: true, message: 'An ontology prefix is required' }]}
+                tooltip={{ title: 'Prefix of the ontology classes that will be used when full IRI is not provided.', color: 'black' }}
               >
                 <Input />
               </Form.Item>
@@ -284,6 +286,7 @@ class DomainCreate extends React.Component<{router, session}, IState> {
                 name="toolsTaxonomyRoot"
                 label="Tools taxonomy root:"
                 rules={[{ required: true, message: 'A tools taxonomy is required' }]}
+                tooltip={{ title: 'Ontology class (full IRI or class label) that corresponds to the tool taxonomy root.', color: 'black' }}
               >
                 <Input />
               </Form.Item>
@@ -291,7 +294,7 @@ class DomainCreate extends React.Component<{router, session}, IState> {
                 name="dataDimensionsTaxonomyRoots"
                 label="Data taxonomy roots:"
                 rules={[{ required: true, message: 'A data taxonomy root is required' }]}
-                tooltip={{ title: 'Press space, comma, or ";" to start typing the next one' }}
+                tooltip={{ title: 'Ontology classes (full IRI or class label) that correspond to the data taxonomy roots, separated by "tab", "space", "comma" or ";".', color: 'black' }}
               >
                 <Select mode="tags" style={{ width: '100%' }} tokenSeparators={[',', ' ', ';']} open={false} />
               </Form.Item>

--- a/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
+++ b/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
@@ -33,6 +33,7 @@ interface IState {
   runConfig: UploadFile<any>[];
   /** The constraints JSON file */
   constraints: UploadFile<any>[];
+  /** Whether each of the tooltip modals are visible. */
   visibleModals: { [name: string]: boolean };
 }
 
@@ -432,19 +433,19 @@ class DomainCreate extends React.Component<{router, session}, IState> {
           </Row>
         </Form>
 
-        { // Ontology file pop-up
+        { // Ontology file modal
           ontologyModal(visibleModals.ontology, () => this.updateModalVisibility('ontology', false))
         }
 
-        { // Tools annotations file pop-up
+        { // Tools annotations file modal
           toolAnnotationsModal(visibleModals.tool_annotations, () => this.updateModalVisibility('tool_annotations', false))
         }
 
-        { // Run configuration file pop-up
+        { // Run configuration file modal
           runConfigModal(visibleModals.run_config, () => this.updateModalVisibility('run_config', false))
         }
 
-        { // Constraints file pop-up
+        { // Constraints file modal
           constraintsModal(visibleModals.constraints, () => this.updateModalVisibility('constraints', false))
         }
       </div>

--- a/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
+++ b/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
@@ -6,13 +6,13 @@
  */
 
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
-import { Select, Form, Result, Button, Input, Upload, message, Col, Row, Space, Popconfirm } from 'antd';
+import React, { ReactNode } from 'react';
+import { Select, Form, Result, Button, Input, Upload, message, Col, Row, Space, Popconfirm, Modal } from 'antd';
 import { Visibility } from '@models/Domain';
 import { fetchTopics } from '@components/Domain/Domain';
 import { validateJSON, validateOWL, onFileChange, ReadMultipleFileContents, RMFCInput } from '@helpers/Files';
 import { useSession } from 'next-auth/client';
-import { UploadOutlined } from '@ant-design/icons';
+import { InfoOutlined, UploadOutlined } from '@ant-design/icons';
 import { UploadFile } from 'antd/lib/upload/interface';
 import { useRouter } from 'next/router';
 import styles from './DomainCreate.module.less';
@@ -33,6 +33,7 @@ interface IState {
   runConfig: UploadFile<any>[];
   /** The constraints JSON file */
   constraints: UploadFile<any>[];
+  visibleModals: { [name: string]: boolean };
 }
 
 /**
@@ -76,6 +77,12 @@ class DomainCreate extends React.Component<{router, session}, IState> {
       toolsAnnotations: [],
       runConfig: [],
       constraints: [],
+      visibleModals: {
+        ontology: false,
+        tool_annotations: false,
+        run_config: false,
+        constraints: false,
+      },
     };
   }
 
@@ -162,10 +169,40 @@ class DomainCreate extends React.Component<{router, session}, IState> {
   };
 
   /**
+   * Change the visibility of a modal by its name.
+   * @param name The name of the modal to change the visibility of.
+   * @param visible Whether the modal should be visible or not.
+   */
+  updateModalVisibility = (name: string, visible: boolean) => {
+    const { visibleModals: modals } = this.state;
+    modals[name] = visible;
+    this.setState({ visibleModals: modals });
+  };
+
+  tooltipModal = (title: string, name: string, visible: boolean, content: ReactNode) => (
+    <Modal
+      title={title}
+      visible={visible}
+      footer={false}
+      onCancel={() => this.updateModalVisibility(name, false)}
+      width={1000}
+    >
+      {content}
+    </Modal>
+  );
+
+  /**
    * Render form
    */
   render() {
-    const { ontology, toolsAnnotations, topics, runConfig, constraints } = this.state;
+    const {
+      ontology,
+      toolsAnnotations,
+      topics,
+      runConfig,
+      constraints,
+      visibleModals,
+    } = this.state;
     const { router } = this.props;
     return (
       <div>
@@ -237,8 +274,17 @@ class DomainCreate extends React.Component<{router, session}, IState> {
               </Form.Item>
               <Form.Item
                 name="useCaseRunConfig"
-                label="Run configuration:"
-                tooltip={{ title: 'Configuration used for a demo run', color: 'black' }}
+                label={(
+                  <div>
+                    Run configuration
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('run_config', true)}
+                    />
+                  </div>
+                )}
               >
                 <Upload
                   beforeUpload={validateJSON}
@@ -255,8 +301,17 @@ class DomainCreate extends React.Component<{router, session}, IState> {
               </Form.Item>
               <Form.Item
                 name="useCaseConstraints"
-                label="Constraints:"
-                tooltip={{ title: 'Constraints used for a demo run', color: 'black' }}
+                label={(
+                  <div>
+                    Constraints
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('constraints', true)}
+                    />
+                  </div>
+                )}
               >
                 <Upload
                   beforeUpload={validateJSON}
@@ -312,7 +367,17 @@ class DomainCreate extends React.Component<{router, session}, IState> {
               </Form.Item>
               <Form.Item
                 name="ontology"
-                label="Ontology file:"
+                label={(
+                  <div>
+                    Ontology file
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('ontology', true)}
+                    />
+                  </div>
+                )}
                 rules={[{ required: true, message: 'An ontology is required' }]}
               >
                 <Upload
@@ -330,7 +395,17 @@ class DomainCreate extends React.Component<{router, session}, IState> {
               </Form.Item>
               <Form.Item
                 name="toolsAnnotations"
-                label="Tool annotations file:"
+                label={(
+                  <div>
+                    Tool annotations file
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('tool_annotations', true)}
+                    />
+                  </div>
+                )}
                 rules={[{ required: true, message: 'A tool annotation is required' }]}
               >
                 <Upload
@@ -368,6 +443,30 @@ class DomainCreate extends React.Component<{router, session}, IState> {
             </Col>
           </Row>
         </Form>
+
+        { // Ontology file pop-up
+          this.tooltipModal('Ontology file', 'ontology', visibleModals.ontology, (
+            <p>Information about ontology files.</p>
+          ))
+        }
+
+        { // Tools annotations file pop-up
+          this.tooltipModal('Tool annotations file', 'tool_annotations', visibleModals.tool_annotations, (
+            <p>Information about tool annotations.</p>
+          ))
+        }
+
+        { // Run configuration file pop-up
+          this.tooltipModal('Run configuration file', 'run_config', visibleModals.run_config, (
+            <p>Information about the run configuration.</p>
+          ))
+        }
+
+        { // Constraints file pop-up
+          this.tooltipModal('Constraints file', 'constraints', visibleModals.constraints, (
+            <p>Information about the constraints file.</p>
+          ))
+        }
       </div>
     );
   }

--- a/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
+++ b/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
@@ -6,10 +6,10 @@
  */
 
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { ReactNode } from 'react';
-import { Select, Form, Result, Button, Input, Upload, message, Col, Row, Space, Popconfirm, Modal } from 'antd';
+import React from 'react';
+import { Select, Form, Result, Button, Input, Upload, message, Col, Row, Space, Popconfirm } from 'antd';
 import { Visibility } from '@models/Domain';
-import { fetchTopics } from '@components/Domain/Domain';
+import { constraintsModal, fetchTopics, ontologyModal, runConfigModal, toolAnnotationsModal } from '@components/Domain/Domain';
 import { validateJSON, validateOWL, onFileChange, ReadMultipleFileContents, RMFCInput } from '@helpers/Files';
 import { useSession } from 'next-auth/client';
 import { InfoOutlined, UploadOutlined } from '@ant-design/icons';
@@ -178,18 +178,6 @@ class DomainCreate extends React.Component<{router, session}, IState> {
     modals[name] = visible;
     this.setState({ visibleModals: modals });
   };
-
-  tooltipModal = (title: string, name: string, visible: boolean, content: ReactNode) => (
-    <Modal
-      title={title}
-      visible={visible}
-      footer={false}
-      onCancel={() => this.updateModalVisibility(name, false)}
-      width={1000}
-    >
-      {content}
-    </Modal>
-  );
 
   /**
    * Render form
@@ -445,27 +433,19 @@ class DomainCreate extends React.Component<{router, session}, IState> {
         </Form>
 
         { // Ontology file pop-up
-          this.tooltipModal('Ontology file', 'ontology', visibleModals.ontology, (
-            <p>Information about ontology files.</p>
-          ))
+          ontologyModal(visibleModals.ontology, () => this.updateModalVisibility('ontology', false))
         }
 
         { // Tools annotations file pop-up
-          this.tooltipModal('Tool annotations file', 'tool_annotations', visibleModals.tool_annotations, (
-            <p>Information about tool annotations.</p>
-          ))
+          toolAnnotationsModal(visibleModals.tool_annotations, () => this.updateModalVisibility('tool_annotations', false))
         }
 
         { // Run configuration file pop-up
-          this.tooltipModal('Run configuration file', 'run_config', visibleModals.run_config, (
-            <p>Information about the run configuration.</p>
-          ))
+          runConfigModal(visibleModals.run_config, () => this.updateModalVisibility('run_config', false))
         }
 
         { // Constraints file pop-up
-          this.tooltipModal('Constraints file', 'constraints', visibleModals.constraints, (
-            <p>Information about the constraints file.</p>
-          ))
+          constraintsModal(visibleModals.constraints, () => this.updateModalVisibility('constraints', false))
         }
       </div>
     );

--- a/front-end/src/components/Domain/DomainEdit/DomainEdit.tsx
+++ b/front-end/src/components/Domain/DomainEdit/DomainEdit.tsx
@@ -8,10 +8,11 @@
 import React from 'react';
 import { NextRouter } from 'next/router';
 import { Button, Col, Form, Input, message, Popconfirm, Row, Select, Space, Upload } from 'antd';
-import { DownloadOutlined, UploadOutlined } from '@ant-design/icons';
+import { DownloadOutlined, InfoOutlined, UploadOutlined } from '@ant-design/icons';
 import { UploadFile } from 'antd/lib/upload/interface';
 import { validateJSON, validateOWL, onFileChange, ReadMultipleFileContents, RMFCInput } from '@helpers/Files';
 import Domain, { Topic, Visibility } from '@models/Domain';
+import { constraintsModal, ontologyModal, runConfigModal, toolAnnotationsModal } from '@components/Domain/Domain';
 import styles from './DomainEdit.module.less';
 
 const { Option } = Select;
@@ -49,6 +50,8 @@ interface IState {
   runConfigFiles: UploadFile<any>[],
   /** Constraint file to upload */
   constraintsFiles: UploadFile<any>[],
+  /** Whether each of the tooltip modals are visible. */
+  visibleModals: { [name: string]: boolean };
 }
 
 /**
@@ -80,6 +83,12 @@ class DomainEdit extends React.Component<IProps, IState> {
       toolsAnnotationsFiles: [],
       runConfigFiles: [],
       constraintsFiles: [],
+      visibleModals: {
+        ontology: false,
+        tool_annotations: false,
+        run_config: false,
+        constraints: false,
+      },
     };
   }
 
@@ -266,6 +275,17 @@ class DomainEdit extends React.Component<IProps, IState> {
     router.push('/');
   };
 
+  /**
+   * Change the visibility of a modal by its name.
+   * @param name The name of the modal to change the visibility of.
+   * @param visible Whether the modal should be visible or not.
+   */
+  updateModalVisibility = (name: string, visible: boolean) => {
+    const { visibleModals: modals } = this.state;
+    modals[name] = visible;
+    this.setState({ visibleModals: modals });
+  };
+
   render() {
     const { domain } = this.props;
     const {
@@ -277,6 +297,7 @@ class DomainEdit extends React.Component<IProps, IState> {
       topicList,
       runConfigFiles,
       constraintsFiles,
+      visibleModals,
     } = this.state;
 
     return (
@@ -350,8 +371,17 @@ class DomainEdit extends React.Component<IProps, IState> {
               </Form.Item>
               <Form.Item
                 name="useCaseRunConfig"
-                label="Run configuration:"
-                tooltip={{ title: 'Configuration used for a demo run', color: 'black' }}
+                label={(
+                  <div>
+                    Run configuration
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('run_config', true)}
+                    />
+                  </div>
+                )}
               >
                 <Space>
                   <Upload
@@ -379,8 +409,17 @@ class DomainEdit extends React.Component<IProps, IState> {
               </Form.Item>
               <Form.Item
                 name="useCaseConstraints"
-                label="Constraints:"
-                tooltip={{ title: 'Constraints used for a demo run', color: 'black' }}
+                label={(
+                  <div>
+                    Constraints
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('constraints', true)}
+                    />
+                  </div>
+                )}
               >
                 <Space>
                   <Upload
@@ -450,7 +489,17 @@ class DomainEdit extends React.Component<IProps, IState> {
               </Form.Item>
 
               <Form.Item
-                label="Ontology file"
+                label={(
+                  <div>
+                    Ontology file
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('ontology', true)}
+                    />
+                  </div>
+                )}
                 name="ontology"
               >
                 <Space>
@@ -478,7 +527,17 @@ class DomainEdit extends React.Component<IProps, IState> {
               </Form.Item>
 
               <Form.Item
-                label="Tools annotations file"
+                label={(
+                  <div>
+                    Tool annotations file
+                    <Button
+                      shape="circle"
+                      size="small"
+                      icon={<InfoOutlined />}
+                      onClick={() => this.updateModalVisibility('tool_annotations', true)}
+                    />
+                  </div>
+                )}
                 name="toolsAnnotations"
               >
                 <Space>
@@ -526,6 +585,22 @@ class DomainEdit extends React.Component<IProps, IState> {
             </Col>
           </Row>
         </Form>
+
+        { // Ontology file modal
+          ontologyModal(visibleModals.ontology, () => this.updateModalVisibility('ontology', false))
+        }
+
+        { // Tools annotations file modal
+          toolAnnotationsModal(visibleModals.tool_annotations, () => this.updateModalVisibility('tool_annotations', false))
+        }
+
+        { // Run configuration file modal
+          runConfigModal(visibleModals.run_config, () => this.updateModalVisibility('run_config', false))
+        }
+
+        { // Constraints file modal
+          constraintsModal(visibleModals.constraints, () => this.updateModalVisibility('constraints', false))
+        }
       </div>
     );
   }

--- a/front-end/src/components/Domain/DomainEdit/DomainEdit.tsx
+++ b/front-end/src/components/Domain/DomainEdit/DomainEdit.tsx
@@ -296,7 +296,7 @@ class DomainEdit extends React.Component<IProps, IState> {
               <Form.Item
                 label="Title"
                 name="title"
-                rules={[{ required: true, message: 'A domain title is required' }]}
+                rules={[{ required: true, message: 'A name is required' }]}
               >
                 <Input />
               </Form.Item>
@@ -322,6 +322,7 @@ class DomainEdit extends React.Component<IProps, IState> {
                       </ul>
                     </div>
                   ),
+                  color: 'black',
                 }}
               >
                 <Select data-testid="visibility-select">
@@ -350,7 +351,7 @@ class DomainEdit extends React.Component<IProps, IState> {
               <Form.Item
                 name="useCaseRunConfig"
                 label="Run configuration:"
-                tooltip={{ title: 'Configuration used for a demo run' }}
+                tooltip={{ title: 'Configuration used for a demo run', color: 'black' }}
               >
                 <Space>
                   <Upload
@@ -379,7 +380,7 @@ class DomainEdit extends React.Component<IProps, IState> {
               <Form.Item
                 name="useCaseConstraints"
                 label="Constraints:"
-                tooltip={{ title: 'Constraints used for a demo run' }}
+                tooltip={{ title: 'Constraints used for a demo run', color: 'black' }}
               >
                 <Space>
                   <Upload
@@ -412,6 +413,7 @@ class DomainEdit extends React.Component<IProps, IState> {
                 label="Ontology prefix"
                 name="ontologyPrefixIRI"
                 rules={[{ required: true, message: 'Ontology prefix is required' }]}
+                tooltip={{ title: 'Prefix of the ontology classes that will be used when full IRI is not provided.', color: 'black' }}
               >
                 <Input />
               </Form.Item>
@@ -420,6 +422,7 @@ class DomainEdit extends React.Component<IProps, IState> {
                 label="Tools taxonomy root"
                 name="toolsTaxonomyRoot"
                 rules={[{ required: true, message: 'Tools taxonomy root is required' }]}
+                tooltip={{ title: 'Ontology class (full IRI or class label) that corresponds to the tool taxonomy root.', color: 'black' }}
               >
                 <Input />
               </Form.Item>
@@ -428,7 +431,7 @@ class DomainEdit extends React.Component<IProps, IState> {
                 name="dataDimensionsTaxonomyRoots"
                 label="Data taxonomy roots:"
                 rules={[{ required: true, message: 'A data taxonomy root is required' }]}
-                tooltip={{ title: 'Press space, comma, or ";" to start typing the next one' }}
+                tooltip={{ title: 'Ontology classes (full IRI or class label) that correspond to the data taxonomy roots, separated by "tab", "space", "comma" or ";".', color: 'black' }}
               >
                 <Select mode="tags" style={{ width: '100%' }} tokenSeparators={[',', ' ', ';']} open={false} />
               </Form.Item>


### PR DESCRIPTION
Improve the current texts of the tooltips in the domain creation page and the domain edit page. Also add new modals that give detailed information on the ontology file, tools annotations file, run config file, and constraints file.

Summary:
- Improved tooltips on the domain creation page.
- Improved tooltips on the domain edit page.