### PR TITLE
[FIX] Data taxonomy roots tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove "tab" as suggestion for separating data taxonomy roots as this also moves the user to the next input field. 
+
 ## [1.4.0] - 2021-11-06
 
 ### Added

--- a/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
+++ b/front-end/src/components/Domain/DomainCreate/DomainCreate.tsx
@@ -338,7 +338,7 @@ class DomainCreate extends React.Component<{router, session}, IState> {
                 name="dataDimensionsTaxonomyRoots"
                 label="Data taxonomy roots:"
                 rules={[{ required: true, message: 'A data taxonomy root is required' }]}
-                tooltip={{ title: 'Ontology classes (full IRI or class label) that correspond to the data taxonomy roots, separated by "tab", "space", "comma" or ";".', color: 'black' }}
+                tooltip={{ title: 'Ontology classes (full IRI or class label) that correspond to the data taxonomy roots, separated by "space", "comma" or ";".', color: 'black' }}
               >
                 <Select mode="tags" style={{ width: '100%' }} tokenSeparators={[',', ' ', ';']} open={false} />
               </Form.Item>

--- a/front-end/src/components/Domain/DomainEdit/DomainEdit.tsx
+++ b/front-end/src/components/Domain/DomainEdit/DomainEdit.tsx
@@ -470,7 +470,7 @@ class DomainEdit extends React.Component<IProps, IState> {
                 name="dataDimensionsTaxonomyRoots"
                 label="Data taxonomy roots:"
                 rules={[{ required: true, message: 'A data taxonomy root is required' }]}
-                tooltip={{ title: 'Ontology classes (full IRI or class label) that correspond to the data taxonomy roots, separated by "tab", "space", "comma" or ";".', color: 'black' }}
+                tooltip={{ title: 'Ontology classes (full IRI or class label) that correspond to the data taxonomy roots, separated by "space", "comma" or ";".', color: 'black' }}
               >
                 <Select mode="tags" style={{ width: '100%' }} tokenSeparators={[',', ' ', ';']} open={false} />
               </Form.Item>


### PR DESCRIPTION
The data taxonomy roots tooltip mentioned you could use "tab" to separate the roots. However, this moves the user to the next input field, which might be confusing. The mention of "tab" has been removed.

Summary:
- Remove "tab" as suggestion for separating data taxonomy roots as this also moves the user to the next input field