### PR TITLE
[FIX] Update APE dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update back-end Kotlin version from 1.3.72 -> 1.6.0.
+- Update APE dependency version 1.1.9 -> 1.1.12 (includes log4j vulnerability fix).
 
 ### Fixed
 

--- a/back-end/pom.xml
+++ b/back-end/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>io.github.sanctuuary</groupId>
 			<artifactId>APE</artifactId>
-			<version>1.1.9</version>
+			<version>1.1.12</version>
 			<exclusions>
 				<exclusion>
 					<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Recenty, [a vulnerability in log4j](https://cve.report/CVE-2021-44228) was disclosed. This merge updates the dependency of APE to the new version with the log4j version which is no longer vulnerable to this exploit.

Summary:
- Update APE dependency version 1.1.9 -> 1.1.12.